### PR TITLE
Add procedural map generation with cellular automata

### DIFF
--- a/game/state.go
+++ b/game/state.go
@@ -8,7 +8,7 @@ type State struct {
 
 // newState creates an initial game state with defaults.
 func newState() *State {
-	world := NewWorld(100, 100)
+	world := GenerateWorld(100, 100, DefaultSeed)
 	player := NewPlayer(world.Width/2, world.Height/2)
 
 	return &State{

--- a/game/worldgen.go
+++ b/game/worldgen.go
@@ -1,0 +1,74 @@
+package game
+
+import "math/rand"
+
+// DefaultSeed is used by newState to produce a consistent map each run.
+// Pass a different seed to GenerateWorld for a different map.
+const DefaultSeed int64 = 42
+
+// GenerateWorld creates a world with procedurally generated forest/grassland
+// terrain using cellular automata. The same seed always produces the same map.
+func GenerateWorld(width, height int, seed int64) *World {
+	rng := rand.New(rand.NewSource(seed)) //nolint:gosec // game RNG, not crypto
+
+	world := NewWorld(width, height)
+
+	// Step 1: Seed each tile with ~60% forest probability.
+	for y := range world.Tiles {
+		for x := range world.Tiles[y] {
+			if rng.Float64() < 0.60 {
+				world.Tiles[y][x].Terrain = Forest
+			}
+		}
+	}
+
+	// Step 2: Smooth with 5 CA iterations.
+	// Rule: a tile becomes Forest if it has >= 5 Forest neighbors (8-directional).
+	// Out-of-bounds positions count as Forest, biasing edges toward Forest.
+	const iterations = 5
+	const forestThreshold = 5
+
+	for range iterations {
+		next := make([][]Tile, height)
+		for y := range next {
+			next[y] = make([]Tile, width)
+			for x := range next[y] {
+				if countForestNeighbors(world, x, y) >= forestThreshold {
+					next[y][x].Terrain = Forest
+				}
+				// else Grassland (zero value, already set by make)
+			}
+		}
+		world.Tiles = next
+	}
+
+	// Step 3: Clear a 5×5 area at the center to guarantee a grassland spawn.
+	cx, cy := width/2, height/2
+	for dy := -2; dy <= 2; dy++ {
+		for dx := -2; dx <= 2; dx++ {
+			if tile := world.TileAt(cx+dx, cy+dy); tile != nil {
+				tile.Terrain = Grassland
+			}
+		}
+	}
+
+	return world
+}
+
+// countForestNeighbors counts Forest neighbors in 8 directions.
+// Out-of-bounds positions are treated as Forest.
+func countForestNeighbors(w *World, x, y int) int {
+	count := 0
+	for dy := -1; dy <= 1; dy++ {
+		for dx := -1; dx <= 1; dx++ {
+			if dx == 0 && dy == 0 {
+				continue
+			}
+			nx, ny := x+dx, y+dy
+			if !w.InBounds(nx, ny) || w.Tiles[ny][nx].Terrain == Forest {
+				count++
+			}
+		}
+	}
+	return count
+}

--- a/game/worldgen_test.go
+++ b/game/worldgen_test.go
@@ -1,0 +1,90 @@
+package game
+
+import "testing"
+
+func TestGenerateWorld_Dimensions(t *testing.T) {
+	w := GenerateWorld(50, 30, 42)
+
+	if w.Width != 50 {
+		t.Errorf("Width = %d, want 50", w.Width)
+	}
+	if w.Height != 30 {
+		t.Errorf("Height = %d, want 30", w.Height)
+	}
+	if len(w.Tiles) != 30 {
+		t.Errorf("tile rows = %d, want 30", len(w.Tiles))
+	}
+	if len(w.Tiles[0]) != 50 {
+		t.Errorf("tile cols = %d, want 50", len(w.Tiles[0]))
+	}
+}
+
+func TestGenerateWorld_Deterministic(t *testing.T) {
+	w1 := GenerateWorld(50, 50, 42)
+	w2 := GenerateWorld(50, 50, 42)
+
+	for y := range w1.Tiles {
+		for x := range w1.Tiles[y] {
+			if w1.Tiles[y][x].Terrain != w2.Tiles[y][x].Terrain {
+				t.Errorf("tile (%d,%d) differs between same-seed runs", x, y)
+			}
+		}
+	}
+}
+
+func TestGenerateWorld_DifferentSeeds(t *testing.T) {
+	w1 := GenerateWorld(50, 50, 42)
+	w2 := GenerateWorld(50, 50, 99)
+
+	different := false
+outer:
+	for y := range w1.Tiles {
+		for x := range w1.Tiles[y] {
+			if w1.Tiles[y][x].Terrain != w2.Tiles[y][x].Terrain {
+				different = true
+				break outer
+			}
+		}
+	}
+
+	if !different {
+		t.Error("different seeds produced identical maps")
+	}
+}
+
+func TestGenerateWorld_ForestDensity(t *testing.T) {
+	w := GenerateWorld(100, 100, 42)
+
+	forest := 0
+	total := w.Width * w.Height
+	for y := range w.Tiles {
+		for x := range w.Tiles[y] {
+			if w.Tiles[y][x].Terrain == Forest {
+				forest++
+			}
+		}
+	}
+
+	pct := float64(forest) / float64(total)
+	if pct < 0.40 || pct > 0.80 {
+		t.Errorf("forest density = %.2f, want between 0.40 and 0.80", pct)
+	}
+}
+
+func TestGenerateWorld_SpawnClear(t *testing.T) {
+	w := GenerateWorld(100, 100, 42)
+	cx, cy := w.Width/2, w.Height/2
+
+	for dy := -2; dy <= 2; dy++ {
+		for dx := -2; dx <= 2; dx++ {
+			tile := w.TileAt(cx+dx, cy+dy)
+			if tile == nil {
+				t.Errorf("tile (%d,%d) is out of bounds", cx+dx, cy+dy)
+				continue
+			}
+			if tile.Terrain != Grassland {
+				t.Errorf("spawn tile (%d,%d) = Forest, want Grassland", cx+dx, cy+dy)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Replaces the flat grassland world with a CA-based generator that produces organic forest blobs covering ~60% of the map. The same seed always yields the same map; DefaultSeed (42) is used at startup.

A 5×5 grassland patch is cleared at the center to guarantee the player always spawns in open terrain.

Replaces the previous flat grassland world creation with a deterministic, seed-driven cellular-automata (CA) terrain generator that produces organic forest/grassland regions and guarantees a clear spawn area at the map center.

Changes:

- Added GenerateWorld(width, height, seed) CA-based world generator (with DefaultSeed).
- Updated startup state initialization to use the new generator instead of NewWorld.
- Added tests covering dimensions, determinism, differing seeds, forest density bounds, and center spawn clearing.