### PR TITLE
Seeded RNG injection for deterministic tests

### DIFF
--- a/e2e_tests/log_storage_test.go
+++ b/e2e_tests/log_storage_test.go
@@ -4,6 +4,7 @@ package e2e_tests
 
 import (
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
@@ -86,7 +87,7 @@ func moveDir(m *render.Model, clock *game.FakeClock, g *game.Game, dir string) {
 func TestLogStorageWorkflow(t *testing.T) {
 	// ── Setup ────────────────────────────────────────────────────────────────
 	clock := game.NewFakeClock()
-	g := game.NewWithClock(clock)
+	g := game.NewWithClockAndRNG(clock, rand.New(rand.NewSource(42)))
 	m := render.NewModelWithClock(g, clock)
 	// Set terminal size so View() renders.
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})

--- a/game/game.go
+++ b/game/game.go
@@ -22,9 +22,15 @@ func New() *Game {
 // NewWithClock creates a new Game with the given clock. Use in tests to
 // inject a FakeClock for deterministic time control.
 func NewWithClock(clock Clock) *Game {
+	return NewWithClockAndRNG(clock, rand.New(rand.NewSource(time.Now().UnixNano())))
+}
+
+// NewWithClockAndRNG creates a new Game with injected clock and RNG. Use in
+// tests to get fully deterministic behavior (e.g. rand.New(rand.NewSource(0))).
+func NewWithClockAndRNG(clock Clock, rng *rand.Rand) *Game {
 	return &Game{
 		State:          newState(),
-		rng:            rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:            rng,
 		regrowCooldown: clock.Now().Add(RegrowthCooldown),
 		clock:          clock,
 	}


### PR DESCRIPTION
## Summary

Adds explicit RNG injection to the game.Game constructor so tests can run deterministically, and wires a fixed RNG seed into the flaky E2E log storage workflow test.

- Add `NewWithClockAndRNG(clock Clock, rng *rand.Rand)` as the base `Game` constructor, following the same injection pattern as `NewWithClock`
- `NewWithClock` delegates to it with a time-seeded RNG (production behavior unchanged)
- Fix `TestLogStorageWorkflow` to use `rand.NewSource(42)` — the E2E test comment already said "seed 42" but wasn't wired up, causing flaky failures when random regrowth grew harvested trees from size 6→7+ (flipping display `t`→`#`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)