### PR TITLE
Fix: villagers stuck at structure corners

### DIFF
--- a/game/villager.go
+++ b/game/villager.go
@@ -330,7 +330,7 @@ func nearestClearTileAdjacent(world *World, stype StructureType, fromX, fromY in
 			continue
 		}
 		fw, fh := entry.Def.Footprint()
-		forFootprintPerimeter(origin.X, origin.Y, fw, fh, func(px, py int) {
+		forFootprintCardinalNeighbors(origin.X, origin.Y, fw, fh, func(px, py int) {
 			tile := world.TileAt(px, py)
 			if tile == nil || tile.Structure != NoStructure {
 				return
@@ -347,15 +347,17 @@ func nearestClearTileAdjacent(world *World, stype StructureType, fromX, fromY in
 	return tx, ty, found
 }
 
-// forFootprintPerimeter calls f for each tile in the 1-tile Chebyshev border
-// around the w×h footprint with top-left at (fx, fy).
-func forFootprintPerimeter(fx, fy, fw, fh int, f func(x, y int)) {
-	// Top and bottom rows (including corners).
-	for x := fx - 1; x <= fx+fw; x++ {
+// forFootprintCardinalNeighbors calls f for each tile that is cardinally
+// (orthogonally) adjacent to the w×h footprint with top-left at (fx, fy).
+// Corner tiles of the Chebyshev border are excluded because they are only
+// diagonally adjacent and villagers cannot interact with a structure from there.
+func forFootprintCardinalNeighbors(fx, fy, fw, fh int, f func(x, y int)) {
+	// Top and bottom edges (no corners).
+	for x := fx; x < fx+fw; x++ {
 		f(x, fy-1)
 		f(x, fy+fh)
 	}
-	// Left and right columns (excluding corners already covered above).
+	// Left and right edges.
 	for y := fy; y < fy+fh; y++ {
 		f(fx-1, y)
 		f(fx+fw, y)

--- a/game/villager_test.go
+++ b/game/villager_test.go
@@ -244,6 +244,58 @@ func TestNearestClearTileAdjacent(t *testing.T) {
 	})
 }
 
+func TestNearestClearTileAdjacentExcludesCorners(t *testing.T) {
+	// 4×4 LogStorage at (5,5) — footprint matches testLogStorageDef.Footprint().
+	// Cardinal neighbors: top y=4 x∈[5,8], bottom y=9 x∈[5,8],
+	//                     left x=4 y∈[5,8], right x=9 y∈[5,8].
+	// Chebyshev corners (excluded): (4,4), (9,4), (4,9), (9,9).
+	w := NewWorld(20, 20)
+	w.SetStructure(5, 5, 4, 4, LogStorage)
+	w.IndexStructure(5, 5, 4, 4, testLogStorageDef{})
+
+	// Block all cardinal neighbors with House tiles (not indexed as LogStorage).
+	for x := 5; x < 9; x++ {
+		w.TileAt(x, 4).Structure = House // top edge
+		w.TileAt(x, 9).Structure = House // bottom edge
+	}
+	for y := 5; y < 9; y++ {
+		w.TileAt(4, y).Structure = House // left edge
+		w.TileAt(9, y).Structure = House // right edge
+	}
+
+	// All cardinal neighbors are blocked; only diagonal corners remain open.
+	// The function must treat corners as non-adjacent and return ok=false.
+	_, _, ok := nearestClearTileAdjacent(w, LogStorage, 7, 7)
+	if ok {
+		t.Error("nearestClearTileAdjacent returned ok=true when only diagonal corners are free; corners must not be considered adjacent")
+	}
+}
+
+func TestNearestClearTileAdjacentReturnedTileIsCardinallyAdjacent(t *testing.T) {
+	// 4×4 LogStorage at (5,5) — footprint matches testLogStorageDef.Footprint().
+	// Chebyshev corners: (4,4), (9,4), (4,9), (9,9) — must never be returned.
+	w := NewWorld(20, 20)
+	w.SetStructure(5, 5, 4, 4, LogStorage)
+	w.IndexStructure(5, 5, 4, 4, testLogStorageDef{})
+
+	corners := map[[2]int]bool{
+		{4, 4}: true, {9, 4}: true,
+		{4, 9}: true, {9, 9}: true,
+	}
+
+	// Run from several positions and confirm no corner is ever returned.
+	for _, from := range [][2]int{{0, 0}, {4, 4}, {9, 9}, {10, 10}} {
+		tx, ty, ok := nearestClearTileAdjacent(w, LogStorage, from[0], from[1])
+		if !ok {
+			t.Errorf("from (%d,%d): expected ok=true", from[0], from[1])
+			continue
+		}
+		if corners[[2]int{tx, ty}] {
+			t.Errorf("from (%d,%d): returned corner tile (%d,%d); corners must be excluded", from[0], from[1], tx, ty)
+		}
+	}
+}
+
 // --- Villager routing around obstacles ---
 
 func TestVillagerRoutesAroundObstacle(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes a bug where villagers would get stuck spinning at diagonal corner tiles of structures, unable to interact with them. The root cause was that nearestClearTileAdjacent used Chebyshev perimeter (including diagonal corners) while deposit/withdraw operations require cardinal (orthogonal) adjacency only.

- `nearestClearTileAdjacent` was using `forFootprintPerimeter` which includes the four diagonal (Chebyshev) corner tiles around a structure's footprint
- Deposit/withdraw checks use **cardinal** adjacency only, so a villager targeted at a corner tile could never interact with the structure and would spin forever
- Replaced `forFootprintPerimeter` with `forFootprintCardinalNeighbors` which emits only the orthogonally-adjacent tiles (top/bottom edges, left/right edges — corners excluded)
- Removed the now-unused `forFootprintPerimeter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)