### PR TITLE
Refactor: extract FinalizeFoundation to deduplicate build-completion logic

### DIFF
--- a/game/structure.go
+++ b/game/structure.go
@@ -28,6 +28,17 @@ type StructureEntry struct {
 	Origin Point
 }
 
+// FinalizeFoundation converts a completed foundation into its built structure type,
+// updates the world index, clears the deposit record, and calls OnBuilt.
+// Call this once the deposited amount has reached or exceeded BuildCost.
+func FinalizeFoundation(env *Env, def StructureDef, origin Point) {
+	w, h := def.Footprint()
+	env.State.World.SetStructure(origin.X, origin.Y, w, h, def.BuiltType())
+	env.State.World.IndexStructure(origin.X, origin.Y, w, h, def)
+	delete(env.State.FoundationDeposited, origin)
+	def.OnBuilt(env, origin)
+}
+
 // structures is the registry of all known structure definitions.
 // Each definition registers itself via init() in its own file.
 var structures []StructureDef

--- a/game/structures/house.go
+++ b/game/structures/house.go
@@ -82,10 +82,6 @@ func (d houseDef) OnPlayerInteraction(env *game.Env, origin game.Point, now time
 	p.Wood--
 	p.QueueCooldown(game.Build, now.Add(p.BuildInterval))
 	if env.State.FoundationDeposited[origin] >= d.BuildCost() {
-		w, h := d.Footprint()
-		env.State.World.SetStructure(origin.X, origin.Y, w, h, game.House)
-		env.State.World.IndexStructure(origin.X, origin.Y, w, h, d)
-		delete(env.State.FoundationDeposited, origin)
-		d.OnBuilt(env, origin)
+		game.FinalizeFoundation(env, d, origin)
 	}
 }

--- a/game/structures/log_storage.go
+++ b/game/structures/log_storage.go
@@ -57,11 +57,7 @@ func (d logStorageDef) OnPlayerInteraction(env *game.Env, origin game.Point, now
 		p.Wood--
 		p.QueueCooldown(game.Build, now.Add(p.BuildInterval))
 		if env.State.FoundationDeposited[origin] >= d.BuildCost() {
-			w, h := d.Footprint()
-			env.State.World.SetStructure(origin.X, origin.Y, w, h, game.LogStorage)
-			env.State.World.IndexStructure(origin.X, origin.Y, w, h, d)
-			delete(env.State.FoundationDeposited, origin)
-			d.OnBuilt(env, origin)
+			game.FinalizeFoundation(env, d, origin)
 		}
 		return
 	}

--- a/game/villager.go
+++ b/game/villager.go
@@ -164,11 +164,7 @@ func (v *Villager) Tick(env *Env, rng *rand.Rand, now time.Time) {
 						env.State.FoundationDeposited[foundOrigin] += deposit
 						v.Wood -= deposit
 						if env.State.FoundationDeposited[foundOrigin] >= buildCost {
-							fw, fh := entry.Def.Footprint()
-							env.State.World.SetStructure(foundOrigin.X, foundOrigin.Y, fw, fh, entry.Def.BuiltType())
-							env.State.World.IndexStructure(foundOrigin.X, foundOrigin.Y, fw, fh, entry.Def)
-							delete(env.State.FoundationDeposited, foundOrigin)
-							entry.Def.OnBuilt(env, foundOrigin)
+							FinalizeFoundation(env, entry.Def, foundOrigin)
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
Rrefactors duplicated foundation finalization logic by extracting it into a centralized function. The four-step sequence for completing a building (SetStructure → IndexStructure → delete deposit → OnBuilt) was copy-pasted in three separate locations, creating maintenance burden and potential for inconsistency.

- The four-line sequence (SetStructure / IndexStructure / delete deposit / OnBuilt) was copy-pasted verbatim in three places: `house.go OnPlayerInteraction`, `log_storage.go OnPlayerInteraction`, and `villager.go VillagerDeliveringToHouse`
- Extracted into `game.FinalizeFoundation(env, def, origin)` in `game/structure.go` and replaced all three call sites
- `OnBuilt` was not the right home — it handles post-build side effects (spawning villagers, registering storage), not the build transition itself; the new free function sits at the right layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)