### PR TITLE
Refactor: convert structure registry from slice to dual-keyed map

### DIFF
--- a/game/progression.go
+++ b/game/progression.go
@@ -16,8 +16,14 @@ func (s *State) HasStructureOfType(stype StructureType) bool {
 
 // findStructureDefByFoundationType returns the StructureDef registered for the
 // given FoundationType, or nil if none is found.
+// The explicit FoundationType check guards against accidentally passing a BuiltType,
+// which would also resolve in the dual-keyed map but is not a valid lookup.
 func findStructureDefByFoundationType(ft StructureType) StructureDef {
-	return structures[ft]
+	def := structures[ft]
+	if def == nil || def.FoundationType() != ft {
+		return nil
+	}
+	return def
 }
 
 // spawnFoundationAt finds a valid location for def and places its foundation tile.

--- a/game/state_test.go
+++ b/game/state_test.go
@@ -41,11 +41,8 @@ func (testHouseDef) OnBuilt(_ *Env, _ Point)                          {}
 func withTestStructures(t *testing.T) {
 	t.Helper()
 	orig := structures
-	d := testLogStorageDef{}
-	structures = map[StructureType]StructureDef{
-		d.FoundationType(): d,
-		d.BuiltType():      d,
-	}
+	structures = map[StructureType]StructureDef{}
+	RegisterStructure(testLogStorageDef{})
 	t.Cleanup(func() { structures = orig })
 }
 
@@ -163,11 +160,8 @@ func TestFoundationLocationBetweenPlayerAndSpawn(t *testing.T) {
 
 func TestHouseWorldConditionSpawnsAfterBuild(t *testing.T) {
 	orig := structures
-	d := testHouseDef{}
-	structures = map[StructureType]StructureDef{
-		d.FoundationType(): d,
-		d.BuiltType():      d,
-	}
+	structures = map[StructureType]StructureDef{}
+	RegisterStructure(testHouseDef{})
 	t.Cleanup(func() { structures = orig })
 
 	w := NewWorld(30, 30)

--- a/game/structure.go
+++ b/game/structure.go
@@ -1,9 +1,12 @@
 package game
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // StructureDef describes the behavior of one structure type.
-// Each structure is registered in the structures slice (see log_storage.go etc.).
+// Each structure is registered in the structures map via RegisterStructure.
 type StructureDef interface {
 	FoundationType() StructureType
 	BuiltType() StructureType
@@ -52,10 +55,10 @@ func RegisterStructure(d StructureDef) {
 		panic("RegisterStructure: def is nil")
 	}
 	if _, exists := structures[d.FoundationType()]; exists {
-		panic("RegisterStructure: FoundationType already registered")
+		panic(fmt.Sprintf("RegisterStructure: FoundationType %d already registered", d.FoundationType()))
 	}
 	if _, exists := structures[d.BuiltType()]; exists {
-		panic("RegisterStructure: BuiltType already registered")
+		panic(fmt.Sprintf("RegisterStructure: BuiltType %d already registered", d.BuiltType()))
 	}
 	structures[d.FoundationType()] = d
 	structures[d.BuiltType()] = d
@@ -64,6 +67,7 @@ func RegisterStructure(d StructureDef) {
 // IterateStructures calls fn once for each registered StructureDef.
 // Because each def is stored under both its FoundationType and BuiltType keys,
 // only the FoundationType entry is visited to avoid double-calling.
+// Iteration order is undefined.
 func IterateStructures(fn func(StructureDef)) {
 	for stype, def := range structures {
 		if stype == def.FoundationType() {


### PR DESCRIPTION
## Summary
Refactors the global structure definition registry to use a dual-keyed map (FoundationType and BuiltType) to enable O(1) lookups and stricter uniqueness guarantees, while adding an iterator helper to avoid double-visiting defs.

- Converts `structures` from `[]StructureDef` to `map[StructureType]StructureDef`, where each def is stored under both its `FoundationType` and `BuiltType` keys
- Tightens the registration uniqueness constraint: each `StructureType` may appear at most once across the entire registry (previously only rejected exact `FoundationType+BuiltType` pairs, missing cases where a type was reused across defs)
- `findStructureDefByFoundationType` becomes an O(1) map lookup instead of a linear scan
- Adds `IterateStructures(fn)` to encapsulate the deduplication logic (visiting only the `FoundationType` entry per def), so callers never need to reason about the dual-keyed layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)