### PR TITLE
Refactor: rename progression.go to spawn.go, extract geom.go

### DIFF
--- a/game/geom.go
+++ b/game/geom.go
@@ -1,0 +1,31 @@
+package game
+
+// abs returns the absolute value of n.
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// chebyshevRingDo calls f(x, y) for every tile on the Chebyshev ring at
+// distance r from (cx, cy). Ring 0 is just the center point.
+func chebyshevRingDo(cx, cy, r int, f func(x, y int)) {
+	if r == 0 {
+		f(cx, cy)
+		return
+	}
+	for dx := -r; dx <= r; dx++ {
+		f(cx+dx, cy-r)
+		f(cx+dx, cy+r)
+	}
+	for dy := -r + 1; dy <= r-1; dy++ {
+		f(cx-r, cy+dy)
+		f(cx+r, cy+dy)
+	}
+}
+
+// manhattan returns the Manhattan distance between two points.
+func manhattan(a, b Point) int {
+	return abs(a.X-b.X) + abs(a.Y-b.Y)
+}

--- a/game/pathfinding.go
+++ b/game/pathfinding.go
@@ -74,11 +74,6 @@ func tileCost(t *Tile) int {
 	return 1
 }
 
-// manhattan returns the Manhattan distance between two points.
-func manhattan(a, b Point) int {
-	return abs(a.X-b.X) + abs(a.Y-b.Y)
-}
-
 // reconstructPath walks cameFrom backwards from goal to start and returns the
 // path exclusive of start, inclusive of goal.
 func reconstructPath(cameFrom map[Point]Point, start, goal Point) []Point {

--- a/game/spawn.go
+++ b/game/spawn.go
@@ -9,11 +9,6 @@ type SpawnAnchoredPlacer interface {
 	UseSpawnAnchoredPlacement() bool
 }
 
-// HasStructureOfType returns true if any tile in the world has the given structure type.
-func (s *State) HasStructureOfType(stype StructureType) bool {
-	return len(s.World.StructureTypeIndex[stype]) > 0
-}
-
 // findStructureDefByFoundationType returns the StructureDef registered for the
 // given FoundationType, or nil if none is found.
 // The explicit FoundationType check guards against accidentally passing a BuiltType,
@@ -83,23 +78,6 @@ func (s *State) findValidLocationNearPlayer(w, h int) (x, y int) {
 		}
 	}
 	return -1, -1
-}
-
-// chebyshevRingDo calls f(x, y) for every tile on the Chebyshev ring at
-// distance r from (cx, cy). Ring 0 is just the center point.
-func chebyshevRingDo(cx, cy, r int, f func(x, y int)) {
-	if r == 0 {
-		f(cx, cy)
-		return
-	}
-	for dx := -r; dx <= r; dx++ {
-		f(cx+dx, cy-r)
-		f(cx+dx, cy+r)
-	}
-	for dy := -r + 1; dy <= r-1; dy++ {
-		f(cx-r, cy+dy)
-		f(cx+r, cy+dy)
-	}
 }
 
 // findValidLocationNearSpawn searches outward from the world spawn point in
@@ -189,11 +167,4 @@ func (s *State) isValidArea(x, y, w, h int) bool {
 	}
 
 	return true
-}
-
-func abs(n int) int {
-	if n < 0 {
-		return -n
-	}
-	return n
 }

--- a/game/state.go
+++ b/game/state.go
@@ -15,6 +15,11 @@ type State struct {
 	CompletedBeats map[string]bool
 }
 
+// HasStructureOfType returns true if any tile in the world has the given structure type.
+func (s *State) HasStructureOfType(stype StructureType) bool {
+	return s.World.HasStructureOfType(stype)
+}
+
 // AddOffer enqueues a card offer by its upgrade IDs.
 func (s *State) AddOffer(ids []string) {
 	if len(ids) == 0 {

--- a/game/world.go
+++ b/game/world.go
@@ -23,6 +23,11 @@ type World struct {
 	regrowCooldown time.Time
 }
 
+// HasStructureOfType returns true if any tile in the world has the given structure type.
+func (w *World) HasStructureOfType(stype StructureType) bool {
+	return len(w.StructureTypeIndex[stype]) > 0
+}
+
 // NewWorld creates a world with the given dimensions, filled with grassland.
 func NewWorld(width, height int) *World {
 	tiles := make([][]Tile, height)


### PR DESCRIPTION
## Summary
Reorganizes game code by renaming progression.go to spawn.go to better reflect its purpose (structure placement logic), extracting shared geometry utilities into a dedicated geom.go file, and moving the HasStructureOfType method from State to World where it logically belongs (with delegation from State for API compatibility).

- Rename `game/progression.go` → `game/spawn.go` — the file contains structure placement/spawning logic, not general progression (story progression is already in `story.go`)
- Extract `abs`, `chebyshevRingDo`, and `manhattan` into new `game/geom.go` — these are geometry helpers already shared between spawn and pathfinding; collecting them in one place makes that explicit
- Move `HasStructureOfType` from a `*State` receiver in `progression.go` to a `*World` receiver in `world.go` — it queries world index state, so `World` is the right owner; a thin `State` delegation is kept in `state.go` so no callers change

🤖 Generated with [Claude Code](https://claude.com/claude-code)