### PR TITLE
Refactor: convert spawn.go methods to free functions with explicit params

### DIFF
--- a/game/spawn.go
+++ b/game/spawn.go
@@ -25,17 +25,17 @@ func findStructureDefByFoundationType(ft StructureType) StructureDef {
 // Placement is near the world spawn point if def implements SpawnAnchoredPlacer,
 // otherwise near the player. Returns true if a foundation was placed, false if no
 // valid location was found (caller may retry on the next tick).
-func (s *State) spawnFoundationAt(def StructureDef) bool {
+func spawnFoundationAt(world *World, playerX, playerY int, def StructureDef) bool {
 	w, h := def.Footprint()
 	var cx, cy int
 	if sa, ok := def.(SpawnAnchoredPlacer); ok && sa.UseSpawnAnchoredPlacement() {
-		cx, cy = s.findValidLocationNearSpawn(w, h)
+		cx, cy = findValidLocationNearSpawn(world, playerX, playerY, w, h)
 	} else {
-		cx, cy = s.findValidLocationNearPlayer(w, h)
+		cx, cy = findValidLocationNearPlayer(world, playerX, playerY, w, h)
 	}
 	if cx >= 0 {
-		s.World.SetStructure(cx, cy, w, h, def.FoundationType())
-		s.World.IndexStructure(cx, cy, w, h, def)
+		world.SetStructure(cx, cy, w, h, def.FoundationType())
+		world.IndexStructure(cx, cy, w, h, def)
 		return true
 	}
 	return false
@@ -44,10 +44,10 @@ func (s *State) spawnFoundationAt(def StructureDef) bool {
 // maybeSpawnFoundation checks each registered structure definition and places a foundation
 // when its ShouldSpawn world condition is met. Each ShouldSpawn implementation is responsible
 // for its own idempotency (e.g. checking that no foundation is already pending).
-func (s *State) maybeSpawnFoundation(env *Env) {
+func maybeSpawnFoundation(env *Env) {
 	IterateStructures(func(def StructureDef) {
 		if def.ShouldSpawn(env) {
-			s.spawnFoundationAt(def)
+			spawnFoundationAt(env.State.World, env.State.Player.X, env.State.Player.Y, def)
 		}
 	})
 }
@@ -55,13 +55,12 @@ func (s *State) maybeSpawnFoundation(env *Env) {
 // findValidLocationNearPlayer walks from the player position toward the world center,
 // returning the top-left corner of the first valid area of the given dimensions.
 // Returns (-1, -1) if no valid location is found.
-func (s *State) findValidLocationNearPlayer(w, h int) (x, y int) {
-	px, py := s.Player.X, s.Player.Y
-	spawnX := s.World.Width / 2
-	spawnY := s.World.Height / 2
+func findValidLocationNearPlayer(world *World, playerX, playerY, footW, footH int) (x, y int) {
+	spawnX := world.Width / 2
+	spawnY := world.Height / 2
 
-	dx := spawnX - px
-	dy := spawnY - py
+	dx := spawnX - playerX
+	dy := spawnY - playerY
 	steps := abs(dx)
 	if abs(dy) > steps {
 		steps = abs(dy)
@@ -71,9 +70,9 @@ func (s *State) findValidLocationNearPlayer(w, h int) (x, y int) {
 	}
 
 	for i := 0; i <= steps; i++ {
-		tx := px + dx*i/steps
-		ty := py + dy*i/steps
-		if s.isValidArea(tx, ty, w, h) {
+		tx := playerX + dx*i/steps
+		ty := playerY + dy*i/steps
+		if isValidArea(world, playerX, playerY, tx, ty, footW, footH) {
 			return tx, ty
 		}
 	}
@@ -82,23 +81,23 @@ func (s *State) findValidLocationNearPlayer(w, h int) (x, y int) {
 
 // findValidLocationNearSpawn searches outward from the world spawn point in
 // expanding Chebyshev rings, returning the top-left corner of the closest valid
-// w×h area by Euclidean distance from footprint center to spawn.
+// footW×footH area by Euclidean distance from footprint center to spawn.
 // Stops as soon as the first valid location is found. Returns (-1, -1) if none found.
-func (s *State) findValidLocationNearSpawn(w, h int) (x, y int) {
-	spawnX := s.World.Width / 2
-	spawnY := s.World.Height / 2
+func findValidLocationNearSpawn(world *World, playerX, playerY, footW, footH int) (x, y int) {
+	spawnX := world.Width / 2
+	spawnY := world.Height / 2
 	// anchorX/anchorY is the top-left that would center the footprint on spawn.
-	anchorX := spawnX - w/2
-	anchorY := spawnY - h/2
+	anchorX := spawnX - footW/2
+	anchorY := spawnY - footH/2
 
 	footprintDist2 := func(px, py int) float64 {
-		cx := float64(px) + float64(w)/2 - float64(spawnX)
-		cy := float64(py) + float64(h)/2 - float64(spawnY)
+		cx := float64(px) + float64(footW)/2 - float64(spawnX)
+		cy := float64(py) + float64(footH)/2 - float64(spawnY)
 		return cx*cx + cy*cy
 	}
 
 	type pos struct{ x, y int }
-	maxR := s.World.Width + s.World.Height
+	maxR := world.Width + world.Height
 
 	for r := 0; r <= maxR; r++ {
 		var ring []pos
@@ -120,7 +119,7 @@ func (s *State) findValidLocationNearSpawn(w, h int) (x, y int) {
 		})
 
 		for _, p := range ring {
-			if s.isValidArea(p.x, p.y, w, h) {
+			if isValidArea(world, playerX, playerY, p.x, p.y, footW, footH) {
 				return p.x, p.y
 			}
 		}
@@ -128,24 +127,22 @@ func (s *State) findValidLocationNearSpawn(w, h int) (x, y int) {
 	return -1, -1
 }
 
-// isValidArea returns true if the w×h area with top-left at (x, y) satisfies
+// isValidArea returns true if the footW×footH area with top-left at (x, y) satisfies
 // all placement constraints:
 //   - Every footprint tile is in-bounds, grassland, and has no structure.
 //   - No footprint tile overlaps the player's current position.
 //   - The full 1-tile Chebyshev border around the footprint contains no structures
 //     (ensures at least a 1-tile gap from every existing structure in all 8 directions).
-func (s *State) isValidArea(x, y, w, h int) bool {
-	px, py := s.Player.X, s.Player.Y
-
+func isValidArea(world *World, playerX, playerY, x, y, footW, footH int) bool {
 	// Check footprint tiles.
-	for dy := 0; dy < h; dy++ {
-		for dx := 0; dx < w; dx++ {
+	for dy := 0; dy < footH; dy++ {
+		for dx := 0; dx < footW; dx++ {
 			tx, ty := x+dx, y+dy
 			// Player overlap check.
-			if tx == px && ty == py {
+			if tx == playerX && ty == playerY {
 				return false
 			}
-			tile := s.World.TileAt(tx, ty)
+			tile := world.TileAt(tx, ty)
 			if tile == nil || tile.Terrain != Grassland || tile.Structure != NoStructure {
 				return false
 			}
@@ -153,13 +150,13 @@ func (s *State) isValidArea(x, y, w, h int) bool {
 	}
 
 	// Check 1-tile Chebyshev border for existing structures.
-	for by := y - 1; by <= y+h; by++ {
-		for bx := x - 1; bx <= x+w; bx++ {
+	for by := y - 1; by <= y+footH; by++ {
+		for bx := x - 1; bx <= x+footW; bx++ {
 			// Skip the footprint itself (already checked above).
-			if bx >= x && bx < x+w && by >= y && by < y+h {
+			if bx >= x && bx < x+footW && by >= y && by < y+footH {
 				continue
 			}
-			tile := s.World.TileAt(bx, by)
+			tile := world.TileAt(bx, by)
 			if tile != nil && tile.Structure != NoStructure {
 				return false
 			}

--- a/game/state.go
+++ b/game/state.go
@@ -66,7 +66,7 @@ func (s *State) SelectCard(idx int) {
 func (s *State) Harvest(env *Env, now time.Time) {
 	IterateResources(func(d ResourceDef) { d.Harvest(env, now) })
 	s.maybeAdvanceStory(env)
-	s.maybeSpawnFoundation(env)
+	maybeSpawnFoundation(env)
 }
 
 // TickAdjacentStructures calls OnPlayerInteraction once per structure instance

--- a/game/state_test.go
+++ b/game/state_test.go
@@ -162,8 +162,7 @@ func TestStoryBeatFiresOnce(t *testing.T) {
 func TestFoundationLocationIsAllGrassland(t *testing.T) {
 	w := NewWorld(30, 30)
 	p := NewPlayer(5, 15)
-	s := &State{Player: p, World: w, FoundationDeposited: make(map[Point]int), CompletedBeats: make(map[string]bool)}
-	s.spawnFoundationAt(testLogStorageDef{})
+	spawnFoundationAt(w, p.X, p.Y, testLogStorageDef{})
 
 	// Find the foundation and verify all 16 tiles are on grassland terrain (underlying).
 	for y := range w.Tiles {
@@ -181,8 +180,7 @@ func TestFoundationLocationBetweenPlayerAndSpawn(t *testing.T) {
 	w := NewWorld(30, 30)
 	// Player at (2, 15); spawn at (15, 15).
 	p := NewPlayer(2, 15)
-	s := &State{Player: p, World: w, FoundationDeposited: make(map[Point]int), CompletedBeats: make(map[string]bool)}
-	s.spawnFoundationAt(testLogStorageDef{})
+	spawnFoundationAt(w, p.X, p.Y, testLogStorageDef{})
 
 	spawnX := w.Width / 2
 	// Find foundation top-left.
@@ -217,7 +215,7 @@ func TestHouseWorldConditionSpawnsAfterBuild(t *testing.T) {
 	env := &Env{State: s, Stores: stores}
 
 	// No house built yet — world condition should not fire.
-	s.maybeSpawnFoundation(env)
+	maybeSpawnFoundation(env)
 	if s.HasStructureOfType(FoundationHouse) {
 		t.Error("house foundation spawned before any house was built")
 	}
@@ -227,13 +225,13 @@ func TestHouseWorldConditionSpawnsAfterBuild(t *testing.T) {
 	w.IndexStructure(10, 10, 2, 2, testHouseDef{})
 
 	// World condition now satisfied: built house exists, no pending foundation.
-	s.maybeSpawnFoundation(env)
+	maybeSpawnFoundation(env)
 	if !s.HasStructureOfType(FoundationHouse) {
 		t.Error("house foundation did not spawn after a house was built")
 	}
 
 	// Second call must not spawn another foundation while one is already pending.
-	s.maybeSpawnFoundation(env)
+	maybeSpawnFoundation(env)
 	if countStructureTiles(w, FoundationHouse) > 4 { // one 2×2 foundation = 4 tiles
 		t.Error("world condition spawned a second house foundation while one was already pending")
 	}

--- a/game/story.go
+++ b/game/story.go
@@ -35,7 +35,7 @@ var storyBeats = []StoryBeat{
 			if def == nil {
 				return false
 			}
-			return env.State.spawnFoundationAt(def)
+			return spawnFoundationAt(env.State.World, env.State.Player.X, env.State.Player.Y, def)
 		},
 	},
 	{
@@ -63,7 +63,7 @@ var storyBeats = []StoryBeat{
 			if def == nil {
 				return false
 			}
-			return env.State.spawnFoundationAt(def)
+			return spawnFoundationAt(env.State.World, env.State.Player.X, env.State.Player.Y, def)
 		},
 	},
 	{


### PR DESCRIPTION
## Summary
Refactors foundation spawning/placement logic to remove *State receivers and use package-level functions with explicit parameters (world + player coordinates), keeping State as a serializable data container and making spawn logic easier to call/test.

- Remove `*State` receiver from all spawn.go functions; replace with `(world *World, playerX, playerY int, ...)` following the `findPath` pattern
- `maybeSpawnFoundation` remains a free function taking `*Env` — it's the one caller that genuinely needs `Env` (for `ShouldSpawn` callbacks)
- Update callers: `state.go` Harvest, `story.go` action closures, `state_test.go` direct test calls
- Two tests that previously constructed a `*State` just to call `spawnFoundationAt` now pass `*World` + player coords directly — cleaner setup

This keeps State as a plain serializable data bag; placement logic is now decoupled from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)