### PR TITLE
Refactor: remove HasStructureOfType shim from State

### DIFF
--- a/e2e_tests/house_test.go
+++ b/e2e_tests/house_test.go
@@ -93,7 +93,7 @@ func TestHouseWorkflow(t *testing.T) {
 	const maxLogStorageTicks = 200
 	for i := range maxLogStorageTicks {
 		tick(&m, clock)
-		if g.State.HasStructureOfType(game.LogStorage) {
+		if g.State.World.HasStructureOfType(game.LogStorage) {
 			break
 		}
 		if i == maxLogStorageTicks-1 {
@@ -173,7 +173,7 @@ func TestHouseWorkflow(t *testing.T) {
 			houseBuildCost, woodForHouse, g.Stores.Total(game.Wood))
 	}
 	// House foundation should NOT have spawned yet (spawns on Phase 7 tick 1).
-	if g.State.HasStructureOfType(game.FoundationHouse) {
+	if g.State.World.HasStructureOfType(game.FoundationHouse) {
 		t.Error("phase 5: house foundation appeared before navigation; expected it to spawn on Phase 7 tick 1")
 	}
 
@@ -212,13 +212,13 @@ func TestHouseWorkflow(t *testing.T) {
 	const maxHouseBuildTicks = 150
 	for i := range maxHouseBuildTicks {
 		tick(&m, clock)
-		if g.State.HasStructureOfType(game.House) {
+		if g.State.World.HasStructureOfType(game.House) {
 			break
 		}
 		if i == maxHouseBuildTicks-1 {
 			t.Fatalf("phase 7: house not built after %d ticks; Wood=%d foundationDeposited=%v hasFoundation=%v",
 				maxHouseBuildTicks, g.State.Player.Inventory[game.Wood],
-				g.State.FoundationDeposited, g.State.HasStructureOfType(game.FoundationHouse))
+				g.State.FoundationDeposited, g.State.World.HasStructureOfType(game.FoundationHouse))
 		}
 	}
 	// Extra tick: first_house_built story beat fires → 2-card offer queued.
@@ -230,7 +230,7 @@ func TestHouseWorkflow(t *testing.T) {
 	announcePhase(m, "Phase 8: Accept house upgrade card")
 
 	// House must be built.
-	if !g.State.HasStructureOfType(game.House) {
+	if !g.State.World.HasStructureOfType(game.House) {
 		t.Fatal("phase 8: House structure not found after build loop")
 	}
 

--- a/e2e_tests/log_storage_test.go
+++ b/e2e_tests/log_storage_test.go
@@ -115,7 +115,7 @@ func TestLogStorageWorkflow(t *testing.T) {
 	const maxHarvestTicks = 30
 	for i := range maxHarvestTicks {
 		tick(&m, clock)
-		if g.State.HasStructureOfType(game.FoundationLogStorage) || g.State.HasStructureOfType(game.LogStorage) {
+		if g.State.World.HasStructureOfType(game.FoundationLogStorage) || g.State.World.HasStructureOfType(game.LogStorage) {
 			break
 		}
 		if i == maxHarvestTicks-1 {
@@ -140,7 +140,7 @@ func TestLogStorageWorkflow(t *testing.T) {
 	const maxBuildTicks = 120
 	for i := range maxBuildTicks {
 		tick(&m, clock)
-		if g.State.HasStructureOfType(game.LogStorage) {
+		if g.State.World.HasStructureOfType(game.LogStorage) {
 			break
 		}
 		if i == maxBuildTicks-1 {
@@ -149,7 +149,7 @@ func TestLogStorageWorkflow(t *testing.T) {
 	}
 
 	// Foundation tiles should be gone; LogStorage should exist.
-	if g.State.HasStructureOfType(game.FoundationLogStorage) {
+	if g.State.World.HasStructureOfType(game.FoundationLogStorage) {
 		t.Error("phase 4: FoundationLogStorage tiles should be gone after build completes")
 	}
 	lsTile := g.State.World.TileAt(49, 48)

--- a/game/state.go
+++ b/game/state.go
@@ -15,11 +15,6 @@ type State struct {
 	CompletedBeats map[string]bool
 }
 
-// HasStructureOfType returns true if any tile in the world has the given structure type.
-func (s *State) HasStructureOfType(stype StructureType) bool {
-	return s.World.HasStructureOfType(stype)
-}
-
 // AddOffer enqueues a card offer by its upgrade IDs.
 func (s *State) AddOffer(ids []string) {
 	if len(ids) == 0 {

--- a/game/state_test.go
+++ b/game/state_test.go
@@ -121,13 +121,13 @@ func TestFoundationSpawnsWhenInventoryFull(t *testing.T) {
 	for i := range InitialCarryingCapacity - 1 {
 		s.Harvest(env, t0.Add(time.Duration(i+1)*HarvestTickInterval*2))
 	}
-	if s.HasStructureOfType(FoundationLogStorage) {
+	if s.World.HasStructureOfType(FoundationLogStorage) {
 		t.Fatal("foundation appeared before inventory full")
 	}
 
 	// Final harvest fills inventory — story beat fires and foundation should now appear.
 	s.Harvest(env, t0.Add(time.Duration(InitialCarryingCapacity)*HarvestTickInterval*2))
-	if !s.HasStructureOfType(FoundationLogStorage) {
+	if !s.World.HasStructureOfType(FoundationLogStorage) {
 		t.Error("foundation did not appear when inventory became full")
 	}
 }
@@ -216,7 +216,7 @@ func TestHouseWorldConditionSpawnsAfterBuild(t *testing.T) {
 
 	// No house built yet — world condition should not fire.
 	maybeSpawnFoundation(env)
-	if s.HasStructureOfType(FoundationHouse) {
+	if s.World.HasStructureOfType(FoundationHouse) {
 		t.Error("house foundation spawned before any house was built")
 	}
 
@@ -226,7 +226,7 @@ func TestHouseWorldConditionSpawnsAfterBuild(t *testing.T) {
 
 	// World condition now satisfied: built house exists, no pending foundation.
 	maybeSpawnFoundation(env)
-	if !s.HasStructureOfType(FoundationHouse) {
+	if !s.World.HasStructureOfType(FoundationHouse) {
 		t.Error("house foundation did not spawn after a house was built")
 	}
 
@@ -271,21 +271,5 @@ func TestAddOfferAndSelectCard(t *testing.T) {
 	}
 	if p.MaxCarry != 100 {
 		t.Errorf("MaxCarry = %d, want 100 after carry capacity upgrade", p.MaxCarry)
-	}
-}
-
-func TestHasStructureOfType(t *testing.T) {
-	w := NewWorld(10, 10)
-	s := &State{Player: NewPlayer(5, 5), World: w}
-
-	if s.HasStructureOfType(LogStorage) {
-		t.Error("should have no LogStorage initially")
-	}
-	w.SetStructure(1, 1, 2, 2, LogStorage)
-	if !s.HasStructureOfType(LogStorage) {
-		t.Error("should detect LogStorage after SetStructure")
-	}
-	if s.HasStructureOfType(FoundationLogStorage) {
-		t.Error("should not detect FoundationLogStorage when none placed")
 	}
 }

--- a/game/story.go
+++ b/game/story.go
@@ -42,7 +42,7 @@ var storyBeats = []StoryBeat{
 		// Queue the carry upgrade offer when the first log storage is completed.
 		ID: "first_log_storage_built",
 		Condition: func(env *Env) bool {
-			return env.State.HasStructureOfType(LogStorage)
+			return env.State.World.HasStructureOfType(LogStorage)
 		},
 		Action: func(env *Env) bool {
 			env.State.AddOffer([]string{"carry_capacity"})
@@ -70,7 +70,7 @@ var storyBeats = []StoryBeat{
 		// Queue the build/deposit speed upgrade offer when the first house is completed.
 		ID: "first_house_built",
 		Condition: func(env *Env) bool {
-			return env.State.HasStructureOfType(House)
+			return env.State.World.HasStructureOfType(House)
 		},
 		Action: func(env *Env) bool {
 			env.State.AddOffer([]string{"build_speed", "deposit_speed"})

--- a/game/structures/house_test.go
+++ b/game/structures/house_test.go
@@ -38,7 +38,7 @@ func TestVillagerSpawnsOnHouseBuilt(t *testing.T) {
 		s.TickAdjacentStructures(env, t0.Add(time.Duration(i)*(game.DepositTickInterval+time.Millisecond)))
 	}
 
-	if !s.HasStructureOfType(game.House) {
+	if !s.World.HasStructureOfType(game.House) {
 		t.Fatal("house was not built after depositing build cost")
 	}
 	if vm.Count() != 1 {

--- a/game/structures/log_storage_test.go
+++ b/game/structures/log_storage_test.go
@@ -63,10 +63,10 @@ func TestFoundationBuildMechanic(t *testing.T) {
 		for i := range logStorageBuildCost {
 			s.TickAdjacentStructures(env, t0.Add(time.Duration(i)*(game.DepositTickInterval+time.Millisecond)))
 		}
-		if s.HasStructureOfType(game.FoundationLogStorage) {
+		if s.World.HasStructureOfType(game.FoundationLogStorage) {
 			t.Error("FoundationLogStorage tiles should be gone after build completes")
 		}
-		if !s.HasStructureOfType(game.LogStorage) {
+		if !s.World.HasStructureOfType(game.LogStorage) {
 			t.Error("LogStorage tiles should exist after build completes")
 		}
 		if s.Player.Inventory[game.Wood] != 0 {

--- a/game/world_test.go
+++ b/game/world_test.go
@@ -194,6 +194,21 @@ func TestIndexStructure(t *testing.T) {
 	})
 }
 
+func TestHasStructureOfType(t *testing.T) {
+	w := NewWorld(10, 10)
+
+	if w.HasStructureOfType(LogStorage) {
+		t.Error("should have no LogStorage initially")
+	}
+	w.SetStructure(1, 1, 2, 2, LogStorage)
+	if !w.HasStructureOfType(LogStorage) {
+		t.Error("should detect LogStorage after SetStructure")
+	}
+	if w.HasStructureOfType(FoundationLogStorage) {
+		t.Error("should not detect FoundationLogStorage when none placed")
+	}
+}
+
 func TestTileAt(t *testing.T) {
 	w := NewWorld(10, 10)
 


### PR DESCRIPTION
## Summary

- Removes `State.HasStructureOfType`, a one-line delegate to `World.HasStructureOfType` that had no business being on the data bag
- Updates all 8 call sites to call `.World.HasStructureOfType(...)` directly
- Moves `TestHasStructureOfType` from `state_test.go` to `world_test.go`, rewritten to test `World` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)