### PR TITLE
Refactor: replace nopDef stub with gametest.WallDef in wood_test.go

### DIFF
--- a/game/resources/wood_test.go
+++ b/game/resources/wood_test.go
@@ -7,19 +7,8 @@ import (
 
 	"forester/game"
 	"forester/game/geom"
+	"forester/game/internal/gametest"
 )
-
-// nopDef is a minimal StructureDef for tests that only need a structure to
-// occupy tiles (e.g. for NoGrowTiles suppression) without any behaviour.
-type nopDef struct{}
-
-func (nopDef) FoundationType() game.StructureType                         { return game.NoStructure }
-func (nopDef) BuiltType() game.StructureType                              { return game.LogStorage }
-func (nopDef) Footprint() (w, h int)                                      { return 1, 1 }
-func (nopDef) BuildCost() int                                             { return 0 }
-func (nopDef) ShouldSpawn(_ *game.Env) bool                               { return false }
-func (nopDef) OnPlayerInteraction(_ *game.Env, _ geom.Point, _ time.Time) {}
-func (nopDef) OnBuilt(_ *game.Env, _ geom.Point)                          {}
 
 // regrowTick calls woodDef.Regrow with a timestamp far enough ahead to fire
 // the regrowth logic regardless of the current cooldown state.
@@ -129,7 +118,7 @@ func TestRegrowWood(t *testing.T) {
 		// tile at (5,10) — distance 5 ≤ 8 from the structure, and distance
 		// sqrt(225+100)=~18 from spawn (safely outside the spawn zone).
 		w := game.NewWorld(40, 40)
-		w.PlaceBuilt(5, 5, nopDef{})
+		w.PlaceBuilt(5, 5, gametest.WallDef{Width: 1, Height: 1})
 		w.Tiles[10][5] = game.Tile{Terrain: game.Forest, TreeSize: 0}
 		env := &game.Env{State: &game.State{World: w}, Stores: game.NewStorageManager()}
 		regrowTick(env, rng, 0)


### PR DESCRIPTION
## Summary
Refactors game/resources/wood_test.go to remove a local StructureDef stub (nopDef) and instead use the shared game/internal/gametest.WallDef helper, keeping the test behavior the same while reducing boilerplate.

- Removes the local `nopDef` type from `game/resources/wood_test.go` (7 boilerplate method stubs)
- Replaces its single usage with `gametest.WallDef{Width: 1, Height: 1}`, the shared helper from `game/internal/gametest`
- Functionally identical: `PlaceBuilt` only reads `BuiltType()` (`LogStorage`) and `Footprint()` (`1×1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)