### PR TITLE
Test: extend TestHouseWorkflow with villager-completes-2nd-house scenario

### DIFF
--- a/e2e_tests/house_test.go
+++ b/e2e_tests/house_test.go
@@ -258,6 +258,128 @@ func TestHouseWorkflow(t *testing.T) {
 		t.Error("phase 8: offer should be cleared after SelectCard")
 	}
 
-	announcePhase(m, fmt.Sprintf("Done — House built! BuildInterval: %v → %v",
-		buildIntervalBefore, g.State.Player.BuildInterval))
+	// ── Phase 9: Verify 1st villager + harvest wood for 2nd house ────────────
+	// After the 1st house is built, 1 villager must have spawned from OnBuilt.
+	// Harvest from the fresh forest belt at x=53 (completely untouched — Phase 3
+	// only swept x=47–49). Route: north×1→(46,50), east×7→(53,50), north×6→(53,44),
+	// then sweep north 3 more positions ticking 15 times each.
+	// Fresh tile count: 4+3×3=13 tiles × min tree size 4 = 52 wood guaranteed.
+	announcePhase(m, "Phase 9: Verify 1st villager, harvest wood for 2nd house")
+	if g.Villagers.Count() != 1 {
+		t.Errorf("phase 9: expected 1 villager after 1st house built, got %d", g.Villagers.Count())
+	}
+
+	moveSafe(&m, clock, g, "w") // north → (46,50): clear of 1st house (y=51+)
+	for range 7 {
+		moveSafe(&m, clock, g, "d") // east → (53,50): below log storage (y=46–49) and house
+	}
+	for range 6 {
+		moveSafe(&m, clock, g, "w") // north → (53,44): east of log storage (x=48–51)
+	}
+	if g.State.Player.X != 53 || g.State.Player.Y != 44 {
+		t.Fatalf("phase 9: expected player at (53,44), got (%d,%d)",
+			g.State.Player.X, g.State.Player.Y)
+	}
+	// Harvest at (53,44) then sweep 3 more positions north; 15 ticks each position.
+	const woodFor2ndHouse = houseBuildCost*9/10 + 1 // 46 (>90% of 50)
+	for range 15 {
+		tick(&m, clock)
+	}
+	for range 3 {
+		moveSafe(&m, clock, g, "w") // north to next fresh arc
+		for range 15 {
+			tick(&m, clock)
+		}
+	}
+	// Player is now at (53,41) after 3 north moves from (53,44).
+	if g.State.Player.X != 53 || g.State.Player.Y != 41 {
+		t.Fatalf("phase 9: expected player at (53,41), got (%d,%d)",
+			g.State.Player.X, g.State.Player.Y)
+	}
+	if g.State.Player.Inventory[game.Wood] < woodFor2ndHouse {
+		t.Fatalf("phase 9: only harvested %d wood; need %d (≥46)",
+			g.State.Player.Inventory[game.Wood], woodFor2ndHouse)
+	}
+
+	// ── Phase 10: Navigate to 2nd house foundation deposit position (49,51) ──────
+	// The 2nd house foundation spawned at (50,51) on the extra tick after the 1st house was
+	// built (houseDef.ShouldSpawn: built≥1 && pending==0; spiral from anchor (49,49) finds
+	// (50,51) as the first valid 2×2 not bordering the log storage or 1st house).
+	// Deposit position (49,51) is directly west of the origin (50,51): adjacent to the
+	// foundation but NOT adjacent to the log storage (nearest storage tile (49,49) is 2 north).
+	// Route from (53,41): south×9→(53,50), west×4→(49,50), south×1→(49,51).
+	announcePhase(m, "Phase 10: Navigate to 2nd foundation deposit position (49,51)")
+	for range 9 {
+		moveSafe(&m, clock, g, "s") // south
+	}
+	for range 4 {
+		moveSafe(&m, clock, g, "a") // west
+	}
+	moveSafe(&m, clock, g, "s") // south → (49,51)
+	if g.State.Player.X != 49 || g.State.Player.Y != 51 {
+		t.Fatalf("phase 10: expected player at (49,51), got (%d,%d)",
+			g.State.Player.X, g.State.Player.Y)
+	}
+	// Verify the 2nd foundation is directly east of the player at (50,51).
+	if tile := g.State.World.TileAt(50, 51); tile == nil || tile.Structure != game.FoundationHouse {
+		t.Fatalf("phase 10: expected FoundationHouse at (50,51), got %v", tile)
+	}
+
+	// ── Phase 11: Player deposits >90% into 2nd foundation, then stops ─────────
+	// Player at (49,51) is cardinally adjacent east to the 2nd foundation origin (50,51).
+	// Each tick deposits 1 wood via OnPlayerInteraction (Build cooldown ≈ 90ms < GameTickInterval).
+	// Break once foundation progress exceeds 90% (>45 of 50 deposited). The villager may also
+	// contribute during these ticks, which only accelerates completion.
+	announcePhase(m, "Phase 11: Player deposits >90% into 2nd foundation, then stops")
+	const maxBuild2Ticks = 120
+	for i := range maxBuild2Ticks {
+		tick(&m, clock)
+		// Check whether the foundation is still in progress and past the 90% threshold.
+		// Note: FoundationProgress returns (0, false) before the first deposit; isBuilt
+		// guards against that case so we never break prematurely on an untouched foundation.
+		isBuilt := g.State.World.CountStructureInstances(game.House) >= 2
+		progress, hasPending := g.State.FoundationProgress()
+		if isBuilt || (hasPending && progress > 0.9) {
+			break
+		}
+		if i == maxBuild2Ticks-1 {
+			t.Fatalf("phase 11: foundation not >90%% complete after %d ticks; progress=%.2f",
+				maxBuild2Ticks, progress)
+		}
+	}
+
+	// ── Phase 12: Player steps back; villager delivers the remaining wood ─────────
+	// If the 2nd house isn't fully built yet (player stopped after >90%), move the player
+	// north to (49,50) — no longer adjacent to the foundation — and let the villager fetch
+	// the remaining wood from the log storage to complete the build.
+	if g.State.World.CountStructureInstances(game.House) < 2 {
+		announcePhase(m, "Phase 12: Player steps back to (49,50); villager completes the 2nd house")
+		moveSafe(&m, clock, g, "w") // north → (49,50); adjacent to log storage, not foundation
+		if g.State.Player.X != 49 || g.State.Player.Y != 50 {
+			t.Fatalf("phase 12: expected player at (49,50), got (%d,%d)",
+				g.State.Player.X, g.State.Player.Y)
+		}
+		const maxVillagerBuildTicks = 200
+		for i := range maxVillagerBuildTicks {
+			tick(&m, clock)
+			if g.State.World.CountStructureInstances(game.House) >= 2 {
+				break
+			}
+			if i == maxVillagerBuildTicks-1 {
+				t.Fatalf("phase 12: villager did not complete 2nd house after %d ticks", maxVillagerBuildTicks)
+			}
+		}
+	}
+
+	// ── Phase 13: Verify 2nd house built + 2nd villager spawned ───────────────
+	announcePhase(m, "Phase 13: Verify 2nd house built and 2nd villager spawned")
+	if g.State.World.CountStructureInstances(game.House) < 2 {
+		t.Fatal("phase 13: 2nd house not built")
+	}
+	if g.Villagers.Count() != 2 {
+		t.Errorf("phase 13: expected 2 villagers after 2nd house built, got %d", g.Villagers.Count())
+	}
+
+	announcePhase(m, fmt.Sprintf("Done — 2 houses built, 2 villagers spawned! BuildInterval: %v",
+		g.State.Player.BuildInterval))
 }


### PR DESCRIPTION
## Summary
Extends the existing TestHouseWorkflow end-to-end test to cover the “second house gets completed by a villager delivery” loop, validating that building a second house results in spawning a second villager.

- Adds phases 9–13 to the existing `TestHouseWorkflow` e2e test
- **Phase 9**: asserts 1 villager spawned after 1st house; harvests fresh wood from the untouched `x=53` forest belt (east of the Phase 3 sweep path at `x=47–49`)
- **Phase 10**: navigates to `(49,51)`, west of the 2nd house foundation at `(50,51)`
- **Phase 11**: player deposits until >90% of the build cost (`houseBuildCost=50`) is in the 2nd foundation
- **Phase 12**: player steps back to `(49,50)` (not adjacent to the foundation); villager fetches remaining wood from the log storage and completes the house
- **Phase 13**: asserts `CountStructureInstances(House) >= 2` and `Villagers.Count() == 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)