### PR TITLE
Feat: multi-foundation build progress UI

### DIFF
--- a/e2e_tests/foundation_progress_test.go
+++ b/e2e_tests/foundation_progress_test.go
@@ -1,0 +1,103 @@
+package e2e_tests
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"forester/game"
+	"forester/game/geom"
+	_ "forester/game/resources"
+	"forester/game/structures"
+	_ "forester/game/upgrades"
+	"forester/render"
+)
+
+// TestFoundationTUIShading verifies that foundation tiles render with different
+// colors at different build progress levels.
+//
+// Setup mirrors TestLogStorageWorkflow (seed 42, player navigated to (48,45))
+// so we know the foundation spawns at origin (48,46).  With terminal 80×24 the
+// foundation origin maps to screen col=40, row=12.
+//
+// The test checks:
+//  1. The character at the foundation tile is always '?'.
+//  2. The raw (ANSI-inclusive) view differs between 0% and 100% progress —
+//     proving the colour changes with build progress.
+func TestFoundationTUIShading(t *testing.T) {
+	clock := game.NewFakeClock()
+	g := game.NewWithClockAndRNG(clock, rand.New(rand.NewSource(42)))
+	m := render.NewModelWithClock(g, clock)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated.(render.Model)
+
+	// Navigate to (48,45) — same path as TestLogStorageWorkflow Phase 1.
+	for _, dir := range []string{"a", "a", "w", "w", "w", "w", "w"} {
+		moveDir(&m, clock, g, dir)
+	}
+
+	// Tick until the log-storage foundation appears (Phase 2).
+	const maxTicks = 30
+	for i := range maxTicks {
+		tick(&m, clock)
+		if g.State.World.HasStructureOfType(structures.FoundationLogStorage) {
+			break
+		}
+		if i == maxTicks-1 {
+			t.Fatal("foundation did not appear within expected ticks")
+		}
+	}
+
+	// Locate the foundation origin in FoundationDeposited.
+	var origin geom.Point
+	for pt := range g.State.FoundationDeposited {
+		origin = pt
+		break
+	}
+	if origin == (geom.Point{}) {
+		t.Fatal("no foundation deposit entry found after foundation spawned")
+	}
+
+	// Foundation origin (48,46) should map to screen col=40, row=12.
+	// vpX = clamp(48-40, 0, max(0,100-80)) = 8
+	// vpY = clamp(45-11, 0, max(0,100-23)) = 34
+	const screenCol, screenRow = 40, 12
+
+	// Verify the tile character is '?' in the stripped view.
+	ch := charAtScreen(m, screenCol, screenRow)
+	if ch != "?" {
+		t.Errorf("foundation tile char = %q, want \"?\"", ch)
+	}
+
+	// Capture raw view at 0% progress.
+	g.State.FoundationDeposited[origin] = 0
+	view0 := m.View()
+
+	// Capture raw view at 100% progress.
+	const logStorageBuildCost = 20
+	g.State.FoundationDeposited[origin] = logStorageBuildCost
+	view100 := m.View()
+
+	// The character must still be '?' at full progress.
+	ch = charAtScreen(m, screenCol, screenRow)
+	if ch != "?" {
+		t.Errorf("foundation tile char at 100%% = %q, want \"?\"", ch)
+	}
+
+	// The stripped (no-ANSI) views at the foundation row must be identical —
+	// same character, just different colours.
+	lines0 := strings.Split(stripANSI(view0), "\n")
+	lines100 := strings.Split(stripANSI(view100), "\n")
+	if screenRow < len(lines0) && screenRow < len(lines100) {
+		if lines0[screenRow] != lines100[screenRow] {
+			t.Errorf("stripped foundation row differs: %q vs %q", lines0[screenRow], lines100[screenRow])
+		}
+	}
+
+	// The raw views must differ — confirming the colour changes with progress.
+	if view0 == view100 {
+		t.Error("raw view unchanged between 0%% and 100%% progress: foundation shading not applied")
+	}
+}

--- a/e2e_tests/foundation_progress_test.go
+++ b/e2e_tests/foundation_progress_test.go
@@ -15,17 +15,39 @@ import (
 	"forester/render"
 )
 
-// TestFoundationTUIShading verifies that foundation tiles render with different
-// colors at different build progress levels.
+// TestFoundationProgressRGB verifies the shared amber→gold color helper that
+// both the TUI and Ebiten renderers use for build-progress shading.
+func TestFoundationProgressRGB(t *testing.T) {
+	tests := []struct {
+		progress            float64
+		wantR, wantG, wantB uint8
+	}{
+		{0.0, 80, 60, 0},   // dark amber
+		{1.0, 255, 215, 0}, // bright gold
+		{0.5, 167, 137, 0}, // midpoint
+	}
+	for _, tt := range tests {
+		r, g, b := render.FoundationProgressRGB(tt.progress)
+		if r != tt.wantR || g != tt.wantG || b != tt.wantB {
+			t.Errorf("FoundationProgressRGB(%.1f) = (%d,%d,%d), want (%d,%d,%d)",
+				tt.progress, r, g, b, tt.wantR, tt.wantG, tt.wantB)
+		}
+	}
+	// Confirm monotonically increasing brightness.
+	r0, g0, _ := render.FoundationProgressRGB(0)
+	r1, g1, _ := render.FoundationProgressRGB(1)
+	if r1 <= r0 || g1 <= g0 {
+		t.Errorf("color should brighten with progress: 0%%=(%d,%d) 100%%=(%d,%d)", r0, g0, r1, g1)
+	}
+}
+
+// TestFoundationTUIShading verifies that foundation tiles render as '?' and
+// that the character is stable across build-progress changes (colour changes,
+// character does not).
 //
 // Setup mirrors TestLogStorageWorkflow (seed 42, player navigated to (48,45))
 // so we know the foundation spawns at origin (48,46).  With terminal 80×24 the
 // foundation origin maps to screen col=40, row=12.
-//
-// The test checks:
-//  1. The character at the foundation tile is always '?'.
-//  2. The raw (ANSI-inclusive) view differs between 0% and 100% progress —
-//     proving the colour changes with build progress.
 func TestFoundationTUIShading(t *testing.T) {
 	clock := game.NewFakeClock()
 	g := game.NewWithClockAndRNG(clock, rand.New(rand.NewSource(42)))
@@ -65,39 +87,32 @@ func TestFoundationTUIShading(t *testing.T) {
 	// vpY = clamp(45-11, 0, max(0,100-23)) = 34
 	const screenCol, screenRow = 40, 12
 
-	// Verify the tile character is '?' in the stripped view.
-	ch := charAtScreen(m, screenCol, screenRow)
-	if ch != "?" {
-		t.Errorf("foundation tile char = %q, want \"?\"", ch)
-	}
-
-	// Capture raw view at 0% progress.
-	g.State.FoundationDeposited[origin] = 0
-	view0 := m.View()
-
-	// Capture raw view at 100% progress.
-	const logStorageBuildCost = 20
-	g.State.FoundationDeposited[origin] = logStorageBuildCost
-	view100 := m.View()
-
-	// The character must still be '?' at full progress.
-	ch = charAtScreen(m, screenCol, screenRow)
-	if ch != "?" {
-		t.Errorf("foundation tile char at 100%% = %q, want \"?\"", ch)
-	}
-
-	// The stripped (no-ANSI) views at the foundation row must be identical —
-	// same character, just different colours.
-	lines0 := strings.Split(stripANSI(view0), "\n")
-	lines100 := strings.Split(stripANSI(view100), "\n")
-	if screenRow < len(lines0) && screenRow < len(lines100) {
-		if lines0[screenRow] != lines100[screenRow] {
-			t.Errorf("stripped foundation row differs: %q vs %q", lines0[screenRow], lines100[screenRow])
+	// Verify the tile character is '?' at 0% and 100% progress.
+	for _, deposited := range []int{0, 10, 20} {
+		g.State.FoundationDeposited[origin] = deposited
+		ch := charAtScreen(m, screenCol, screenRow)
+		if ch != "?" {
+			t.Errorf("foundation tile char at %d deposited = %q, want \"?\"", deposited, ch)
 		}
 	}
 
-	// The raw views must differ — confirming the colour changes with progress.
-	if view0 == view100 {
-		t.Error("raw view unchanged between 0%% and 100%% progress: foundation shading not applied")
+	// The stripped (no-ANSI) foundation row must be identical regardless of
+	// progress — same '?' character, only the colour wrapping changes.
+	g.State.FoundationDeposited[origin] = 0
+	row0 := strings.Split(stripANSI(m.View()), "\n")[screenRow]
+	g.State.FoundationDeposited[origin] = 20
+	row100 := strings.Split(stripANSI(m.View()), "\n")[screenRow]
+	if row0 != row100 {
+		t.Errorf("stripped foundation row differs at 0%% vs 100%%: %q vs %q", row0, row100)
+	}
+
+	// FoundationProgressAt must return correct progress for tiles in the footprint.
+	g.State.FoundationDeposited[origin] = 10
+	progress, ok := g.State.FoundationProgressAt(origin)
+	if !ok {
+		t.Error("FoundationProgressAt(origin): ok = false after deposit")
+	}
+	if progress != 0.5 {
+		t.Errorf("FoundationProgressAt(origin) = %v, want 0.5", progress)
 	}
 }

--- a/e2e_tests/house_test.go
+++ b/e2e_tests/house_test.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"forester/game"
+	"forester/game/geom"
 	_ "forester/game/resources"
 	"forester/game/structures"
 	_ "forester/game/upgrades"
@@ -320,10 +321,10 @@ func TestHouseWorkflow(t *testing.T) {
 	for i := range maxBuild2Ticks {
 		tickDraining(&m, clock, g) // auto-drain any XP milestone offers
 		// Check whether the foundation is still in progress and past the 90% threshold.
-		// Note: FoundationProgress returns (0, false) before the first deposit; isBuilt
+		// Note: FoundationProgressAt returns (0, false) before the first deposit; isBuilt
 		// guards against that case so we never break prematurely on an untouched foundation.
 		isBuilt := g.State.World.CountStructureInstances(structures.House) >= 2
-		progress, hasPending := g.State.FoundationProgress()
+		progress, hasPending := g.State.FoundationProgressAt(geom.Point{X: 50, Y: 51})
 		if isBuilt || (hasPending && progress > 0.9) {
 			break
 		}

--- a/game/state.go
+++ b/game/state.go
@@ -29,21 +29,14 @@ func (s *State) AddOffer(ids []string) {
 	s.pendingOfferIDs = append(s.pendingOfferIDs, ids)
 }
 
-// FoundationProgress returns the build progress (0.0–1.0) of the first active foundation,
-// and whether any foundation is in progress. Uses structureIndex to look up BuildCost.
-func (s *State) FoundationProgress() (float64, bool) {
-	for origin, deposited := range s.FoundationDeposited {
-		entry, ok := s.World.structureIndex[origin]
-		if !ok {
-			continue
-		}
-		cost := entry.Def.BuildCost()
-		if cost == 0 {
-			continue
-		}
-		return float64(deposited) / float64(cost), true
+// FoundationProgress returns the build progress (0.0–1.0) of the first active
+// foundation, and whether any foundation is in progress.
+func (s *State) FoundationProgress() (progress float64, ok bool) {
+	all := s.AllFoundationsProgress()
+	if len(all) == 0 {
+		return 0, false
 	}
-	return 0, false
+	return all[0].Progress, true
 }
 
 // FoundationInfo holds rendering data for one active foundation.

--- a/game/state.go
+++ b/game/state.go
@@ -46,6 +46,55 @@ func (s *State) FoundationProgress() (float64, bool) {
 	return 0, false
 }
 
+// FoundationInfo holds rendering data for one active foundation.
+type FoundationInfo struct {
+	Origin   geom.Point
+	Width    int
+	Height   int
+	Progress float64 // 0.0–1.0
+}
+
+// AllFoundationsProgress returns FoundationInfo for every active foundation.
+func (s *State) AllFoundationsProgress() []FoundationInfo {
+	var result []FoundationInfo
+	for origin, deposited := range s.FoundationDeposited {
+		entry, ok := s.World.structureIndex[origin]
+		if !ok {
+			continue
+		}
+		cost := entry.Def.BuildCost()
+		if cost == 0 {
+			continue
+		}
+		w, h := entry.Def.Footprint()
+		result = append(result, FoundationInfo{
+			Origin:   origin,
+			Width:    w,
+			Height:   h,
+			Progress: float64(deposited) / float64(cost),
+		})
+	}
+	return result
+}
+
+// FoundationProgressAt returns the build progress (0.0–1.0) for the foundation
+// that owns tile pt, or (0, false) if pt is not part of an active foundation.
+func (s *State) FoundationProgressAt(pt geom.Point) (progress float64, ok bool) {
+	entry, exists := s.World.structureIndex[pt]
+	if !exists {
+		return 0, false
+	}
+	deposited, active := s.FoundationDeposited[entry.Origin]
+	if !active {
+		return 0, false
+	}
+	cost := entry.Def.BuildCost()
+	if cost == 0 {
+		return 0, false
+	}
+	return float64(deposited) / float64(cost), true
+}
+
 // newState creates an initial game state with defaults.
 func newState() *State {
 	world := GenerateWorld(100, 100, defaultSeed)

--- a/game/state.go
+++ b/game/state.go
@@ -29,16 +29,6 @@ func (s *State) AddOffer(ids []string) {
 	s.pendingOfferIDs = append(s.pendingOfferIDs, ids)
 }
 
-// FoundationProgress returns the build progress (0.0–1.0) of the first active
-// foundation, and whether any foundation is in progress.
-func (s *State) FoundationProgress() (progress float64, ok bool) {
-	all := s.AllFoundationsProgress()
-	if len(all) == 0 {
-		return 0, false
-	}
-	return all[0].Progress, true
-}
-
 // FoundationInfo holds rendering data for one active foundation.
 type FoundationInfo struct {
 	Origin   geom.Point

--- a/game/state_test.go
+++ b/game/state_test.go
@@ -1,0 +1,119 @@
+package game
+
+import (
+	"testing"
+
+	"forester/game/geom"
+	"forester/game/internal/gametest"
+)
+
+func makeStateWithFoundation(t *testing.T) (*State, geom.Point) {
+	t.Helper()
+	w := NewWorld(20, 20)
+	def := gametest.LogStorageDef{} // 4×4, BuildCost=20
+	origin := geom.Point{X: 2, Y: 3}
+	w.PlaceFoundation(origin.X, origin.Y, def)
+	s := &State{
+		World:               w,
+		FoundationDeposited: make(map[point]int),
+	}
+	return s, origin
+}
+
+func TestAllFoundationsProgress_empty(t *testing.T) {
+	w := NewWorld(10, 10)
+	s := &State{
+		World:               w,
+		FoundationDeposited: make(map[point]int),
+	}
+	got := s.AllFoundationsProgress()
+	if len(got) != 0 {
+		t.Errorf("AllFoundationsProgress() len = %d, want 0", len(got))
+	}
+}
+
+func TestAllFoundationsProgress_one(t *testing.T) {
+	s, origin := makeStateWithFoundation(t)
+	s.FoundationDeposited[origin] = 10 // 10/20 = 50%
+
+	got := s.AllFoundationsProgress()
+	if len(got) != 1 {
+		t.Fatalf("AllFoundationsProgress() len = %d, want 1", len(got))
+	}
+	fi := got[0]
+	if fi.Origin != origin {
+		t.Errorf("Origin = %v, want %v", fi.Origin, origin)
+	}
+	if fi.Width != 4 || fi.Height != 4 {
+		t.Errorf("Footprint = %dx%d, want 4x4", fi.Width, fi.Height)
+	}
+	if fi.Progress != 0.5 {
+		t.Errorf("Progress = %v, want 0.5", fi.Progress)
+	}
+}
+
+func TestAllFoundationsProgress_two(t *testing.T) {
+	w := NewWorld(20, 20)
+	def := gametest.LogStorageDef{} // 4×4, BuildCost=20
+	o1 := geom.Point{X: 1, Y: 1}
+	o2 := geom.Point{X: 10, Y: 10}
+	w.PlaceFoundation(o1.X, o1.Y, def)
+	w.PlaceFoundation(o2.X, o2.Y, def)
+	s := &State{
+		World:               w,
+		FoundationDeposited: map[point]int{o1: 4, o2: 16},
+	}
+
+	got := s.AllFoundationsProgress()
+	if len(got) != 2 {
+		t.Fatalf("AllFoundationsProgress() len = %d, want 2", len(got))
+	}
+	byOrigin := make(map[geom.Point]float64, 2)
+	for _, fi := range got {
+		byOrigin[fi.Origin] = fi.Progress
+	}
+	if byOrigin[o1] != 0.2 {
+		t.Errorf("progress at o1 = %v, want 0.2", byOrigin[o1])
+	}
+	if byOrigin[o2] != 0.8 {
+		t.Errorf("progress at o2 = %v, want 0.8", byOrigin[o2])
+	}
+}
+
+func TestFoundationProgressAt_originTile(t *testing.T) {
+	s, origin := makeStateWithFoundation(t)
+	s.FoundationDeposited[origin] = 5 // 5/20 = 0.25
+
+	got, ok := s.FoundationProgressAt(origin)
+	if !ok {
+		t.Fatal("FoundationProgressAt(origin): ok = false, want true")
+	}
+	if got != 0.25 {
+		t.Errorf("FoundationProgressAt(origin) = %v, want 0.25", got)
+	}
+}
+
+func TestFoundationProgressAt_nonOriginTile(t *testing.T) {
+	s, origin := makeStateWithFoundation(t)
+	s.FoundationDeposited[origin] = 15 // 15/20 = 0.75
+
+	// Any tile within the 4×4 footprint (not origin) should also return progress.
+	inner := geom.Point{X: origin.X + 2, Y: origin.Y + 2}
+	got, ok := s.FoundationProgressAt(inner)
+	if !ok {
+		t.Fatal("FoundationProgressAt(inner tile): ok = false, want true")
+	}
+	if got != 0.75 {
+		t.Errorf("FoundationProgressAt(inner tile) = %v, want 0.75", got)
+	}
+}
+
+func TestFoundationProgressAt_noFoundation(t *testing.T) {
+	s, _ := makeStateWithFoundation(t)
+	// Don't add any deposited amount — tile exists but no foundation progress entry.
+	empty := geom.Point{X: 15, Y: 15}
+	_, ok := s.FoundationProgressAt(empty)
+	if ok {
+		t.Error("FoundationProgressAt(empty tile): ok = true, want false")
+	}
+}

--- a/render/ebiten_model.go
+++ b/render/ebiten_model.go
@@ -238,6 +238,7 @@ func (e *EbitenGame) Draw(screen *ebiten.Image) {
 		}
 	}
 
+	drawFoundationOverlays(screen, e.game, vpX, vpY)
 	drawHUD(screen, e.game, e.hudFace, e.screenW, e.screenH)
 	if e.debugVillager {
 		drawVillagerDebugBar(screen, e.game, e.hudFace, e.screenW, e.screenH, e.debugVillagerIdx)

--- a/render/hud.go
+++ b/render/hud.go
@@ -22,10 +22,6 @@ const (
 	foundationBarInset   = 2 // pixels inset from left and right edges
 )
 
-var (
-	colorFoundationBarBG = color.RGBA{0, 0, 0, 160}
-)
-
 // drawFoundationOverlays draws a colored progress bar above each active
 // foundation that is visible in the current viewport. The bar floats
 // foundationBarPadding pixels above the top edge of the foundation footprint
@@ -46,23 +42,23 @@ func drawFoundationOverlays(screen *ebiten.Image, g *game.Game, vpX, vpY int) {
 		vector.FillRect(screen, sx, sy, barW, foundationBarHeight, colorFoundationBarBG, false)
 
 		// Fill using shared amber→gold progression.
-		r, g2, b := FoundationProgressRGB(fi.Progress)
-		fillColor := color.RGBA{R: r, G: g2, B: b, A: 220}
+		cr, cg, cb := FoundationProgressRGB(fi.Progress)
 		if fillW > 0 {
-			vector.FillRect(screen, sx, sy, fillW, foundationBarHeight, fillColor, false)
+			vector.FillRect(screen, sx, sy, fillW, foundationBarHeight, color.RGBA{R: cr, G: cg, B: cb, A: 220}, false)
 		}
 	}
 }
 
 var (
-	colorHUDBG      = color.RGBA{0, 0, 0, 200}
-	colorHUDText    = color.RGBA{255, 255, 255, 255}
-	colorOverlay    = color.RGBA{0, 0, 0, 180}
-	colorCardBG     = color.RGBA{42, 42, 42, 255}
-	colorCardBorder = color.RGBA{212, 168, 64, 255}
-	colorCardTitle  = color.RGBA{255, 255, 255, 255}
-	colorCardDesc   = color.RGBA{204, 204, 204, 255}
-	colorCardHint   = color.RGBA{255, 215, 0, 255}
+	colorHUDBG           = color.RGBA{0, 0, 0, 200}
+	colorFoundationBarBG = color.RGBA{0, 0, 0, 160}
+	colorHUDText         = color.RGBA{255, 255, 255, 255}
+	colorOverlay         = color.RGBA{0, 0, 0, 180}
+	colorCardBG          = color.RGBA{42, 42, 42, 255}
+	colorCardBorder      = color.RGBA{212, 168, 64, 255}
+	colorCardTitle       = color.RGBA{255, 255, 255, 255}
+	colorCardDesc        = color.RGBA{204, 204, 204, 255}
+	colorCardHint        = color.RGBA{255, 215, 0, 255}
 	// colorTitlePanelBG intentionally shares the card background color.
 	colorTitlePanelBG = colorCardBG
 )

--- a/render/hud.go
+++ b/render/hud.go
@@ -46,7 +46,7 @@ func drawFoundationOverlays(screen *ebiten.Image, g *game.Game, vpX, vpY int) {
 		vector.FillRect(screen, sx, sy, barW, foundationBarHeight, colorFoundationBarBG, false)
 
 		// Fill using shared amber→gold progression.
-		r, g2, b := foundationProgressRGB(fi.Progress)
+		r, g2, b := FoundationProgressRGB(fi.Progress)
 		fillColor := color.RGBA{R: r, G: g2, B: b, A: 220}
 		if fillW > 0 {
 			vector.FillRect(screen, sx, sy, fillW, foundationBarHeight, fillColor, false)
@@ -99,10 +99,6 @@ func drawHUD(screen *ebiten.Image, g *game.Game, face *textv2.GoXFace, screenW, 
 
 	xp, nextMilestone := g.XPInfo()
 	status += fmt.Sprintf("  XP: %d/%d", xp, nextMilestone)
-
-	if progress, ok := g.State.FoundationProgress(); ok {
-		status += "  " + buildProgressBar(progress)
-	}
 
 	op := &textv2.DrawOptions{}
 	op.GeoM.Translate(8, float64(screenH-hudHeight)+4)

--- a/render/hud.go
+++ b/render/hud.go
@@ -16,6 +16,44 @@ import (
 
 const hudHeight = 20
 
+const (
+	foundationBarHeight  = 4
+	foundationBarPadding = 2 // pixels above the top edge of the tile
+	foundationBarInset   = 2 // pixels inset from left and right edges
+)
+
+var (
+	colorFoundationBarBG = color.RGBA{0, 0, 0, 160}
+)
+
+// drawFoundationOverlays draws a colored progress bar above each active
+// foundation that is visible in the current viewport. The bar floats
+// foundationBarPadding pixels above the top edge of the foundation footprint
+// and spans the full footprint width (minus foundationBarInset on each side).
+// Color transitions from dark amber (0%) to bright gold (100%) using the same
+// progression as the TUI shading.
+func drawFoundationOverlays(screen *ebiten.Image, g *game.Game, vpX, vpY int) {
+	for _, fi := range g.State.AllFoundationsProgress() {
+		sx := float32((fi.Origin.X-vpX)*tileSize + foundationBarInset)
+		sy := float32((fi.Origin.Y-vpY)*tileSize - foundationBarHeight - foundationBarPadding)
+		if sy < 0 {
+			continue // bar would be above the viewport
+		}
+		barW := float32(fi.Width*tileSize - 2*foundationBarInset)
+		fillW := barW * float32(fi.Progress)
+
+		// Background.
+		vector.FillRect(screen, sx, sy, barW, foundationBarHeight, colorFoundationBarBG, false)
+
+		// Fill using shared amber→gold progression.
+		r, g2, b := foundationProgressRGB(fi.Progress)
+		fillColor := color.RGBA{R: r, G: g2, B: b, A: 220}
+		if fillW > 0 {
+			vector.FillRect(screen, sx, sy, fillW, foundationBarHeight, fillColor, false)
+		}
+	}
+}
+
 var (
 	colorHUDBG      = color.RGBA{0, 0, 0, 200}
 	colorHUDText    = color.RGBA{255, 255, 255, 255}

--- a/render/tui_model.go
+++ b/render/tui_model.go
@@ -16,12 +16,31 @@ import (
 	"forester/game/structures"
 )
 
+// foundationStyleCache memoizes lipgloss styles keyed by progress value.
+// It is cleared every foundationStyleCacheTTL to bound its lifetime.
+var (
+	foundationStyleCache       = make(map[float64]lipgloss.Style)
+	foundationStyleCacheExpiry time.Time
+)
+
+const foundationStyleCacheTTL = 10 * time.Second
+
 // foundationProgressStyle returns a lipgloss style whose foreground is the
 // same amber→gold color used by the Ebiten progress bar overlay.
+// Results are memoized; the cache is cleared every foundationStyleCacheTTL.
 func foundationProgressStyle(progress float64) lipgloss.Style {
-	r, g, b := FoundationProgressRGB(progress)
-	hex := fmt.Sprintf("#%02X%02X%02X", r, g, b)
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(hex))
+	now := time.Now()
+	if now.After(foundationStyleCacheExpiry) {
+		clear(foundationStyleCache)
+		foundationStyleCacheExpiry = now.Add(foundationStyleCacheTTL)
+	}
+	if s, ok := foundationStyleCache[progress]; ok {
+		return s
+	}
+	cr, cg, cb := FoundationProgressRGB(progress)
+	s := lipgloss.NewStyle().Foreground(lipgloss.Color(fmt.Sprintf("#%02X%02X%02X", cr, cg, cb)))
+	foundationStyleCache[progress] = s
+	return s
 }
 
 // TickMsg is sent each tick interval to drive the game loop.

--- a/render/tui_model.go
+++ b/render/tui_model.go
@@ -16,6 +16,14 @@ import (
 	"forester/game/structures"
 )
 
+// foundationProgressStyle returns a lipgloss style whose foreground is the
+// same amber→gold color used by the Ebiten progress bar overlay.
+func foundationProgressStyle(progress float64) lipgloss.Style {
+	r, g, b := foundationProgressRGB(progress)
+	hex := fmt.Sprintf("#%02X%02X%02X", r, g, b)
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(hex))
+}
+
 // TickMsg is sent each tick interval to drive the game loop.
 type TickMsg time.Time
 
@@ -29,7 +37,6 @@ var (
 	playerStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))            // blue
 	forestStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))             // green
 	stumpStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))             // dark gray
-	foundationStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))             // yellow (dim)
 	logStorageStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true)  // bold yellow
 	houseStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)  // bold magenta
 	resourceDepotStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true) // bold cyan
@@ -190,7 +197,8 @@ func (m Model) View() string {
 			// Structure overlays take priority over terrain.
 			switch tile.Structure {
 			case structures.FoundationLogStorage, structures.FoundationHouse, structures.FoundationResourceDepot:
-				sb.WriteString(foundationStyle.Render("?"))
+				progress, _ := m.game.State.FoundationProgressAt(geom.Point{X: worldX, Y: worldY})
+				sb.WriteString(foundationProgressStyle(progress).Render("?"))
 				continue
 			case structures.LogStorage:
 				sb.WriteString(logStorageStyle.Render("L"))

--- a/render/tui_model.go
+++ b/render/tui_model.go
@@ -19,7 +19,7 @@ import (
 // foundationProgressStyle returns a lipgloss style whose foreground is the
 // same amber→gold color used by the Ebiten progress bar overlay.
 func foundationProgressStyle(progress float64) lipgloss.Style {
-	r, g, b := foundationProgressRGB(progress)
+	r, g, b := FoundationProgressRGB(progress)
 	hex := fmt.Sprintf("#%02X%02X%02X", r, g, b)
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(hex))
 }
@@ -258,9 +258,6 @@ func (m Model) View() string {
 	xp, nextMilestone := m.game.XPInfo()
 	status += fmt.Sprintf("  XP: %d/%d", xp, nextMilestone)
 
-	if progress, ok := m.game.State.FoundationProgress(); ok {
-		status += "  " + buildProgressBar(progress)
-	}
 	sb.WriteByte('\n')
 	sb.WriteString(status)
 

--- a/render/util.go
+++ b/render/util.go
@@ -1,8 +1,6 @@
 package render
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"forester/game"
@@ -49,24 +47,16 @@ func clampF(v, lo, hi float64) float64 {
 	return v
 }
 
-// foundationProgressRGB returns a linearly interpolated amber→gold RGB color
+// FoundationProgressRGB returns a linearly interpolated amber→gold RGB color
 // for the given build progress (0.0–1.0). Used by both the TUI and Ebiten
 // renderers so both use the same color progression.
 //
 // 0%  → dark amber  (80,  60,  0)
 // 100% → bright gold (255, 215, 0)
-func foundationProgressRGB(progress float64) (r, g, b uint8) {
+func FoundationProgressRGB(progress float64) (r, g, b uint8) {
 	p := clampF(progress, 0, 1)
 	r = uint8(80 + p*175)
 	g = uint8(60 + p*155)
 	b = 0
 	return
-}
-
-// buildProgressBar renders a text progress bar, e.g. "Building: ████░░░░ 75%".
-func buildProgressBar(progress float64) string {
-	const width = 8
-	filled := clamp(int(progress*width), 0, width)
-	bar := strings.Repeat("█", filled) + strings.Repeat("░", width-filled)
-	return fmt.Sprintf("Building: %s %d%%", bar, int(progress*100))
 }

--- a/render/util.go
+++ b/render/util.go
@@ -49,6 +49,20 @@ func clampF(v, lo, hi float64) float64 {
 	return v
 }
 
+// foundationProgressRGB returns a linearly interpolated amber→gold RGB color
+// for the given build progress (0.0–1.0). Used by both the TUI and Ebiten
+// renderers so both use the same color progression.
+//
+// 0%  → dark amber  (80,  60,  0)
+// 100% → bright gold (255, 215, 0)
+func foundationProgressRGB(progress float64) (r, g, b uint8) {
+	p := clampF(progress, 0, 1)
+	r = uint8(80 + p*175)
+	g = uint8(60 + p*155)
+	b = 0
+	return
+}
+
 // buildProgressBar renders a text progress bar, e.g. "Building: ████░░░░ 75%".
 func buildProgressBar(progress float64) string {
 	const width = 8

--- a/render/util.go
+++ b/render/util.go
@@ -57,6 +57,5 @@ func FoundationProgressRGB(progress float64) (r, g, b uint8) {
 	p := clampF(progress, 0, 1)
 	r = uint8(80 + p*175)
 	g = uint8(60 + p*155)
-	b = 0
-	return
+	return // b stays zero
 }


### PR DESCRIPTION
## Summary

- **Game layer**: adds `AllFoundationsProgress()` and `FoundationProgressAt()` on `State`, exposing per-foundation origin/footprint/progress for all active foundations simultaneously
- **Ebiten**: draws a colored progress bar (dark amber → bright gold) floating above the top edge of each active foundation's pixel footprint; bar spans the full structure width and is clipped if above the viewport
- **TUI**: foundation `?` tiles shade continuously from dark amber to bright gold based on build progress, using the same `FoundationProgressRGB()` color helper; styles are memoized with a 10s TTL to avoid per-tile allocations on every frame
- **HUD cleanup**: removes the redundant single-foundation text bar from the status line in both renderers

## Test plan

- [ ] `make check` passes (lint + unit + E2E)
- [ ] `TestFoundationProgressRGB` — verifies amber→gold color values at 0%, 50%, 100%
- [ ] `TestFoundationTUIShading` — foundation tile renders as `?` at all progress levels; stripped row is stable; `FoundationProgressAt` returns correct ratio
- [ ] Unit tests in `game/state_test.go` — `AllFoundationsProgress` and `FoundationProgressAt` for zero, one, and two concurrent foundations including non-origin tile lookup
- [ ] Manual: `make run`, place a foundation, watch bar appear and grow as wood is deposited; place two foundations simultaneously and verify both bars render independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)