### PR TITLE
Harden setup-new-worktree.sh hook

### DIFF
--- a/.claude/hooks/setup-new-worktree.sh
+++ b/.claude/hooks/setup-new-worktree.sh
@@ -8,12 +8,21 @@ INPUT=$(cat)
 # The WorktreeCreate payload has no path field; derive the path from the worktree name.
 # Worktrees are always created at $CLAUDE_PROJECT_DIR/.claude/worktrees/<name>.
 NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
-WORKTREE="${CLAUDE_PROJECT_DIR}/.claude/worktrees/${NAME}"
 
 if [ -z "$NAME" ]; then
   echo "setup-new-worktree: could not read name from hook input" >&2
   exit 1
 fi
+
+WORKTREE="${CLAUDE_PROJECT_DIR}/.claude/worktrees/${NAME}"
+
+if [ -d "$WORKTREE" ]; then
+  echo "setup-new-worktree: worktree already exists at $WORKTREE" >&2
+  exit 1
+fi
+
+# Remove the worktree dir on failure so we don't leave partial state.
+trap 'rm -rf "$WORKTREE"' ERR
 
 # Create the git worktree on a new branch.
 mkdir -p "${CLAUDE_PROJECT_DIR}/.claude/worktrees"

--- a/.claude/hooks/setup-new-worktree.sh
+++ b/.claude/hooks/setup-new-worktree.sh
@@ -1,19 +1,31 @@
 #!/bin/bash
-# Copies gitignored sprite assets into a new worktree so go:embed targets compile.
-# go:embed does not follow symlinks, so assets must be physically present in the worktree.
+# Creates a git worktree and copies gitignored sprite assets into it so
+# go:embed targets compile. go:embed does not follow symlinks, so assets
+# must be physically present in the worktree.
 set -euo pipefail
 
 INPUT=$(cat)
-WORKTREE=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin)['worktree_path'])")
+# The WorktreeCreate payload has no path field; derive the path from the worktree name.
+# Worktrees are always created at $CLAUDE_PROJECT_DIR/.claude/worktrees/<name>.
+NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
+WORKTREE="${CLAUDE_PROJECT_DIR}/.claude/worktrees/${NAME}"
 
-if [ -z "$WORKTREE" ]; then
-  echo "setup-new-worktree: could not read worktree_path from hook input" >&2
+if [ -z "$NAME" ]; then
+  echo "setup-new-worktree: could not read name from hook input" >&2
   exit 1
 fi
 
+# Create the git worktree on a new branch.
+mkdir -p "${CLAUDE_PROJECT_DIR}/.claude/worktrees"
+git -C "$CLAUDE_PROJECT_DIR" worktree add "$WORKTREE" -b "$NAME" HEAD >&2
+
+# Copy gitignored sprite assets so go:embed targets compile.
 SPRITES="${CLAUDE_PROJECT_DIR}/assets/sprites"
 if [ -d "$SPRITES" ]; then
   mkdir -p "$WORKTREE/assets/sprites"
   cp -r "$SPRITES/." "$WORKTREE/assets/sprites/"
-  echo "Copied sprites to $WORKTREE/assets/sprites/"
+  echo "Copied sprites to $WORKTREE/assets/sprites/" >&2
 fi
+
+# Output the worktree path on stdout — the tool uses this as the handoff signal.
+echo "$WORKTREE"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ assets/sprites/lpc*
 assets/sprites/player-spritesheet.*
 assets/sprites/container-v4_2*
 
+# Claude
+.claude/worktrees


### PR DESCRIPTION
## Summary

- Validate `NAME` before deriving `WORKTREE` so the guard fires before any directory is created
- Exit early with a clear error if the worktree dir already exists, preventing silent overwrites or branch-name collisions
- Add `ERR` trap to remove the worktree dir on unexpected failures during setup, avoiding partial state

## Test plan

- [ ] Create a new worktree via `EnterWorktree` — confirm it succeeds and sprites are copied
- [ ] Attempt to create a worktree with a name that already exists — confirm the script exits with a clear error message and leaves no partial state

🤖 Generated with [Claude Code](https://claude.com/claude-code)