### PR TITLE
Refactor: extract Ebitengine renderer to render/gui/ to fix headless CI

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	_ "forester/game/resources"
 	_ "forester/game/structures"
 	_ "forester/game/upgrades"
-	"forester/render"
+	gui "forester/render/gui"
 )
 
 func main() {
@@ -24,7 +24,7 @@ func main() {
 	ebiten.SetWindowSize(1280, 720)
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 	ebiten.SetWindowTitle("Forester")
-	if err := ebiten.RunGame(render.NewEbitenGame(g)); err != nil {
+	if err := ebiten.RunGame(gui.NewEbitenGame(g)); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/render/gui/hud.go
+++ b/render/gui/hud.go
@@ -1,9 +1,10 @@
-package render
+package gui
 
 import (
 	"fmt"
 	"image/color"
 	"strings"
+	"unicode/utf8"
 
 	ebiten "github.com/hajimehoshi/ebiten/v2"
 	textv2 "github.com/hajimehoshi/ebiten/v2/text/v2"
@@ -12,6 +13,7 @@ import (
 
 	"forester/game"
 	"forester/game/structures"
+	"forester/render"
 )
 
 const hudHeight = 20
@@ -47,7 +49,7 @@ func drawFoundationOverlays(screen *ebiten.Image, g *game.Game, camX, camY, zoom
 		vector.FillRect(screen, sx, sy, barW, foundationBarHeight, colorFoundationBarBG, false)
 
 		// Fill using shared amber→gold progression.
-		cr, cg, cb := FoundationProgressRGB(fi.Progress)
+		cr, cg, cb := render.FoundationProgressRGB(fi.Progress)
 		if fillW > 0 {
 			vector.FillRect(screen, sx, sy, fillW, foundationBarHeight, color.RGBA{R: cr, G: cg, B: cb, A: 220}, false)
 		}
@@ -120,10 +122,15 @@ func drawStatusBar(screen *ebiten.Image, msg string, face *textv2.GoXFace, scree
 	textv2.Draw(screen, " "+msg, face, op)
 }
 
-// drawVillagerDebugBar renders a second HUD row above the main status bar showing
-// debug info for the selected villager.
-func drawVillagerDebugBar(screen *ebiten.Image, g *game.Game, face *textv2.GoXFace, screenW, screenH, idx int) {
-	barY := screenH - hudHeight*2
+// drawVillagerDebugBar renders a HUD row above the status bar showing debug info
+// for the selected villager. Pass shiftUp=true when the status bar is also visible
+// so the two bars stack rather than overlap.
+func drawVillagerDebugBar(screen *ebiten.Image, g *game.Game, face *textv2.GoXFace, screenW, screenH, idx int, shiftUp bool) {
+	slot := 2
+	if shiftUp {
+		slot = 3
+	}
+	barY := screenH - hudHeight*slot
 	vector.FillRect(screen,
 		0, float32(barY),
 		float32(screenW), float32(hudHeight),
@@ -135,7 +142,7 @@ func drawVillagerDebugBar(screen *ebiten.Image, g *game.Game, face *textv2.GoXFa
 	if n == 0 {
 		text = " Debug: no villagers"
 	} else {
-		i := clamp(idx, 0, n-1)
+		i := render.Clamp(idx, 0, n-1)
 		v := villagers[i]
 		text = fmt.Sprintf(" Debug V%d/%d  Pos: (%d,%d)  Task: %s  Target: (%d,%d)  Wood: %d/%d",
 			i+1, n, v.X, v.Y, v.Task, v.TargetX, v.TargetY, v.Wood, game.VillagerMaxCarry)
@@ -218,7 +225,7 @@ func wrapDescription(text string, maxLen int) []string {
 	return lines
 }
 
-// wrapParagraph breaks a single paragraph into lines no longer than maxLen characters.
+// wrapParagraph breaks a single paragraph into lines no longer than maxLen runes.
 func wrapParagraph(text string, maxLen int) []string {
 	words := strings.Fields(text)
 	if len(words) == 0 {
@@ -226,15 +233,20 @@ func wrapParagraph(text string, maxLen int) []string {
 	}
 	var lines []string
 	var current strings.Builder
+	currentLen := 0 // rune count of current line
 	for _, w := range words {
-		if current.Len() > 0 && current.Len()+1+len(w) > maxLen {
+		wLen := utf8.RuneCountInString(w)
+		if currentLen > 0 && currentLen+1+wLen > maxLen {
 			lines = append(lines, current.String())
 			current.Reset()
+			currentLen = 0
 		}
-		if current.Len() > 0 {
+		if currentLen > 0 {
 			current.WriteByte(' ')
+			currentLen++
 		}
 		current.WriteString(w)
+		currentLen += wLen
 	}
 	if current.Len() > 0 {
 		lines = append(lines, current.String())

--- a/render/gui/model.go
+++ b/render/gui/model.go
@@ -1,4 +1,4 @@
-package render
+package gui
 
 import (
 	"image/color"
@@ -11,9 +11,8 @@ import (
 
 	"forester/game"
 	"forester/game/geom"
+	"forester/render"
 )
-
-const tileSize = 32
 
 const (
 	zoomMin     = 0.75
@@ -61,7 +60,7 @@ func NewEbitenGame(g *game.Game) *EbitenGame {
 
 // applyZoom multiplies the current zoom by delta and clamps to [zoomMin, zoomMax].
 func (e *EbitenGame) applyZoom(delta float64) {
-	e.zoom = clampF(e.zoom*delta, zoomMin, zoomMax)
+	e.zoom = render.ClampF(e.zoom*delta, zoomMin, zoomMax)
 }
 
 // saveGame syncs zoom into game state then saves.
@@ -185,8 +184,8 @@ func (e *EbitenGame) Update() error {
 	viewW := int(math.Ceil(float64(e.screenW)/scaledTile)) + 1
 	viewH := int(math.Ceil(float64(e.screenH)/scaledTile)) + 1
 	// Use exact screen-pixel math so the target is a continuous function of zoom.
-	targetCamX := clampF(float64(player.X)-float64(e.screenW)/(2*scaledTile), 0, float64(max(0, world.Width-viewW)))
-	targetCamY := clampF(float64(player.Y)-float64(e.screenH)/(2*scaledTile), 0, float64(max(0, world.Height-viewH)))
+	targetCamX := render.ClampF(float64(player.X)-float64(e.screenW)/(2*scaledTile), 0, float64(max(0, world.Width-viewW)))
+	targetCamY := render.ClampF(float64(player.Y)-float64(e.screenH)/(2*scaledTile), 0, float64(max(0, world.Height-viewH)))
 	if e.zoom != prevZoom {
 		e.camX = targetCamX
 		e.camY = targetCamY
@@ -333,11 +332,13 @@ func (e *EbitenGame) Draw(screen *ebiten.Image) {
 
 	drawFoundationOverlays(screen, e.game, e.camX, e.camY, e.zoom)
 	drawHUD(screen, e.game, e.hudFace, e.screenW, e.screenH)
+	statusMsg := render.SaveStatusText(e.game.Status.Code)
+	statusActive := statusMsg != "" && now.Before(e.game.Status.SetAt.Add(render.StatusDuration))
 	if e.debugVillager {
-		drawVillagerDebugBar(screen, e.game, e.hudFace, e.screenW, e.screenH, e.debugVillagerIdx)
+		drawVillagerDebugBar(screen, e.game, e.hudFace, e.screenW, e.screenH, e.debugVillagerIdx, statusActive)
 	}
-	if msg := saveStatusText(e.game.Status.Code); msg != "" && now.Before(e.game.Status.SetAt.Add(statusDuration)) {
-		drawStatusBar(screen, msg, e.hudFace, e.screenW, e.screenH)
+	if statusActive {
+		drawStatusBar(screen, statusMsg, e.hudFace, e.screenW, e.screenH)
 	}
 }
 

--- a/render/gui/sprites.go
+++ b/render/gui/sprites.go
@@ -1,4 +1,4 @@
-package render
+package gui
 
 import (
 	"image"
@@ -110,6 +110,9 @@ func initResourceDepotPlaceholder() {
 	img.Fill(color.RGBA{R: 0xD4, G: 0x7F, B: 0x00, A: 0xFF}) // amber/gold
 	resourceDepotPlaceholderImg = img
 }
+
+// tileSize is the side length in pixels of one world tile at zoom=1.
+const tileSize = 32
 
 // Universal LPC spritesheet constants (64×64 px per frame).
 // Row groups each have 4 rows: +0=up, +1=left, +2=down, +3=right.

--- a/render/tui_model.go
+++ b/render/tui_model.go
@@ -28,8 +28,9 @@ const foundationStyleCacheTTL = 10 * time.Second
 // foundationProgressStyle returns a lipgloss style whose foreground is the
 // same amber→gold color used by the Ebiten progress bar overlay.
 // Results are memoized; the cache is cleared every foundationStyleCacheTTL.
-func foundationProgressStyle(progress float64) lipgloss.Style {
-	now := time.Now()
+// now should come from the model's clock so tests with a FakeClock expire the
+// cache predictably.
+func foundationProgressStyle(now time.Time, progress float64) lipgloss.Style {
 	if now.After(foundationStyleCacheExpiry) {
 		clear(foundationStyleCache)
 		foundationStyleCacheExpiry = now.Add(foundationStyleCacheTTL)
@@ -166,8 +167,9 @@ func (m Model) View() string {
 
 	// Status bar occupies the last line; map gets the rest.
 	// Debug bar (when visible) and save/load status each take one additional line.
-	statusMsg := saveStatusText(m.game.Status.Code)
-	statusActive := statusMsg != "" && m.clock.Now().Before(m.game.Status.SetAt.Add(statusDuration))
+	now := m.clock.Now()
+	statusMsg := SaveStatusText(m.game.Status.Code)
+	statusActive := statusMsg != "" && now.Before(m.game.Status.SetAt.Add(StatusDuration))
 	mapHeight := m.termHeight - 1
 	if m.debugVillager {
 		mapHeight--
@@ -182,8 +184,8 @@ func (m Model) View() string {
 
 	// Top-left corner of the viewport in world coordinates.
 	// Center the viewport on the player, clamped to world bounds.
-	vpX := clamp(player.X-mapWidth/2, 0, max(0, world.Width-mapWidth))
-	vpY := clamp(player.Y-mapHeight/2, 0, max(0, world.Height-mapHeight))
+	vpX := Clamp(player.X-mapWidth/2, 0, max(0, world.Width-mapWidth))
+	vpY := Clamp(player.Y-mapHeight/2, 0, max(0, world.Height-mapHeight))
 
 	// Build a position set for O(1) villager lookup during rendering.
 	villagerPos := make(map[geom.Point]struct{}, m.game.Villagers.Count())
@@ -217,7 +219,7 @@ func (m Model) View() string {
 			switch tile.Structure {
 			case structures.FoundationLogStorage, structures.FoundationHouse, structures.FoundationResourceDepot:
 				progress, _ := m.game.State.FoundationProgressAt(geom.Point{X: worldX, Y: worldY})
-				sb.WriteString(foundationProgressStyle(progress).Render("?"))
+				sb.WriteString(foundationProgressStyle(now, progress).Render("?"))
 				continue
 			case structures.LogStorage:
 				sb.WriteString(logStorageStyle.Render("L"))
@@ -299,7 +301,7 @@ func (m Model) villagerDebugBar() string {
 	if n == 0 {
 		return " Debug: no villagers"
 	}
-	idx := clamp(m.debugVillagerIdx, 0, n-1)
+	idx := Clamp(m.debugVillagerIdx, 0, n-1)
 	v := villagers[idx]
 	return fmt.Sprintf(" Debug V%d/%d  Pos: (%d,%d)  Task: %s  Target: (%d,%d)  Wood: %d/%d",
 		idx+1, n, v.X, v.Y, v.Task, v.TargetX, v.TargetY, v.Wood, game.VillagerMaxCarry)

--- a/render/util.go
+++ b/render/util.go
@@ -6,11 +6,11 @@ import (
 	"forester/game"
 )
 
-// statusDuration is how long a save/load status message is shown.
-const statusDuration = 2 * time.Second
+// StatusDuration is how long a save/load status message is shown.
+const StatusDuration = 2 * time.Second
 
-// saveStatusText returns the display string for a SaveStatusCode, or "" for none.
-func saveStatusText(code game.SaveStatusCode) string {
+// SaveStatusText returns the display string for a SaveStatusCode, or "" for none.
+func SaveStatusText(code game.SaveStatusCode) string {
 	switch code {
 	case game.SaveStatusSaved:
 		return "Game saved"
@@ -27,7 +27,8 @@ func saveStatusText(code game.SaveStatusCode) string {
 	}
 }
 
-func clamp(v, lo, hi int) int {
+// Clamp returns v clamped to [lo, hi].
+func Clamp(v, lo, hi int) int {
 	if v < lo {
 		return lo
 	}
@@ -37,7 +38,8 @@ func clamp(v, lo, hi int) int {
 	return v
 }
 
-func clampF(v, lo, hi float64) float64 {
+// ClampF returns v clamped to [lo, hi].
+func ClampF(v, lo, hi float64) float64 {
 	if v < lo {
 		return lo
 	}
@@ -54,8 +56,6 @@ func clampF(v, lo, hi float64) float64 {
 // 0%  → dark amber  (80,  60,  0)
 // 100% → bright gold (255, 215, 0)
 func FoundationProgressRGB(progress float64) (r, g, b uint8) {
-	p := clampF(progress, 0, 1)
-	r = uint8(80 + p*175)
-	g = uint8(60 + p*155)
-	return // b stays zero
+	p := ClampF(progress, 0, 1)
+	return uint8(80 + p*175), uint8(60 + p*155), 0
 }


### PR DESCRIPTION
## Summary

- Importing `render/` in `e2e_tests/` pulled in `ebiten/v2` which initialises GLFW, causing a nil-pointer panic in headless environments (no display server). Fix: move all Ebitengine-specific files into a new `render/gui/` subpackage so `render/` is Ebitengine-free — `e2e_tests/` imports unchanged.
- Export shared helpers (`Clamp`, `ClampF`, `SaveStatusText`, `StatusDuration`) from `render/util.go` so `render/gui` can call them via `render.*`.
- Fix debug bar / status bar layout overlap: when both are visible simultaneously, the status bar overwrote the debug bar at the same y position. `drawVillagerDebugBar` now accepts `shiftUp bool` and bumps to the third HUD slot when needed.
- `foundationStyleCache` TTL used `time.Now()` instead of the injected model clock; fixed to accept `now time.Time` so `FakeClock`-based tests expire the cache predictably.
- `wrapParagraph` measured word length in bytes (`len`); replaced with `utf8.RuneCountInString` for correct Unicode handling.
- `FoundationProgressRGB` used a bare named `return`; replaced with explicit `return r, g, 0`.
- `tileSize` const moved from `model.go` to `sprites.go` where sprite geometry lives.

## Test plan

- [x] `make check` passes (lint + tests including e2e)
- [x] `make build` compiles binary
- [x] `make wasm` compiles WASM target

🤖 Generated with [Claude Code](https://claude.ai/claude-code)